### PR TITLE
Feature/forms parent id mapping

### DIFF
--- a/src/client/src/content/app/components/authenticated/routes/AttributeFormRoutes.tsx
+++ b/src/client/src/content/app/components/authenticated/routes/AttributeFormRoutes.tsx
@@ -3,5 +3,5 @@ import { AttributeForm } from "../../../../forms/attribute/AttributeForm";
 
 export const attributeFormRoutes: RouteObject[] = [
   { path: "form/attribute", element: <AttributeForm /> },
-  { path: "form/attribute/clone/:id", element: <AttributeForm /> },
+  { path: "form/attribute/clone/:id", element: <AttributeForm mode={"clone"} /> },
 ];

--- a/src/client/src/content/app/components/authenticated/routes/InterfaceFormRoutes.tsx
+++ b/src/client/src/content/app/components/authenticated/routes/InterfaceFormRoutes.tsx
@@ -3,6 +3,6 @@ import { InterfaceForm } from "../../../../forms/interface/InterfaceForm";
 
 export const interfaceFormRoutes: RouteObject[] = [
   { path: "form/interface", element: <InterfaceForm /> },
-  { path: "form/interface/clone/:id", element: <InterfaceForm /> },
-  { path: "form/interface/edit/:id", element: <InterfaceForm isEdit /> },
+  { path: "form/interface/clone/:id", element: <InterfaceForm mode={"clone"} /> },
+  { path: "form/interface/edit/:id", element: <InterfaceForm mode={"edit"} /> },
 ];

--- a/src/client/src/content/app/components/authenticated/routes/NodeFormRoutes.tsx
+++ b/src/client/src/content/app/components/authenticated/routes/NodeFormRoutes.tsx
@@ -3,6 +3,6 @@ import { NodeForm } from "../../../../forms/node/NodeForm";
 
 export const nodeFormRoutes: RouteObject[] = [
   { path: "form/node", element: <NodeForm /> },
-  { path: "form/node/clone/:id", element: <NodeForm /> },
-  { path: "form/node/edit/:id", element: <NodeForm isEdit /> },
+  { path: "form/node/clone/:id", element: <NodeForm mode={"clone"} /> },
+  { path: "form/node/edit/:id", element: <NodeForm mode={"edit"} /> },
 ];

--- a/src/client/src/content/app/components/authenticated/routes/TerminalFormRoutes.tsx
+++ b/src/client/src/content/app/components/authenticated/routes/TerminalFormRoutes.tsx
@@ -3,6 +3,6 @@ import { TerminalForm } from "../../../../forms/terminal/TerminalForm";
 
 export const terminalFormRoutes: RouteObject[] = [
   { path: "form/terminal", element: <TerminalForm /> },
-  { path: "form/terminal/clone/:id", element: <TerminalForm /> },
-  { path: "form/terminal/edit/:id", element: <TerminalForm isEdit /> },
+  { path: "form/terminal/clone/:id", element: <TerminalForm mode={"clone"} /> },
+  { path: "form/terminal/edit/:id", element: <TerminalForm mode={"edit"} /> },
 ];

--- a/src/client/src/content/app/components/authenticated/routes/TransportFormRoutes.tsx
+++ b/src/client/src/content/app/components/authenticated/routes/TransportFormRoutes.tsx
@@ -3,6 +3,6 @@ import { TransportForm } from "../../../../forms/transport/TransportForm";
 
 export const transportFormRoutes: RouteObject[] = [
   { path: "form/transport", element: <TransportForm /> },
-  { path: "form/transport/clone/:id", element: <TransportForm /> },
-  { path: "form/transport/edit/:id", element: <TransportForm isEdit /> },
+  { path: "form/transport/clone/:id", element: <TransportForm mode={"clone"} /> },
+  { path: "form/transport/edit/:id", element: <TransportForm mode={"edit"} /> },
 ];

--- a/src/client/src/content/forms/attribute/AttributeForm.tsx
+++ b/src/client/src/content/forms/attribute/AttributeForm.tsx
@@ -16,6 +16,7 @@ import { showSelectValues, useAttributeQuery } from "./AttributeForm.helpers";
 import { AttributeFormContainer } from "./AttributeForm.styled";
 import { AttributeFormBaseFields } from "./AttributeFormBaseFields";
 import { attributeSchema } from "./attributeSchema";
+import { AttributeFormMode } from "./types/attributeFormMode";
 import {
   createEmptyFormAttributeLib,
   FormAttributeLib,
@@ -27,7 +28,7 @@ import { AttributeFormValues } from "./values/AttributeFormValues";
 
 interface AttributeFormProps {
   defaultValues?: FormAttributeLib;
-  isEdit?: boolean;
+  mode?: AttributeFormMode;
 }
 
 export const AttributeForm = ({ defaultValues = createEmptyFormAttributeLib() }: AttributeFormProps) => {

--- a/src/client/src/content/forms/attribute/types/attributeFormMode.ts
+++ b/src/client/src/content/forms/attribute/types/attributeFormMode.ts
@@ -1,0 +1,1 @@
+export type AttributeFormMode = "clone";

--- a/src/client/src/content/forms/interface/InterfaceForm.helpers.ts
+++ b/src/client/src/content/forms/interface/InterfaceForm.helpers.ts
@@ -1,16 +1,17 @@
 import { useParams } from "react-router-dom";
 import { useCreateInterface, useGetInterface, useUpdateInterface } from "../../../data/queries/tyle/queriesInterface";
 import { FormInterfaceLib } from "./types/formInterfaceLib";
+import { InterfaceFormMode } from "./types/interfaceFormMode";
 
 export const useInterfaceQuery = () => {
   const { id } = useParams();
   return useGetInterface(id);
 };
 
-export const useInterfaceMutation = (isEdit?: boolean) => {
+export const useInterfaceMutation = (mode?: InterfaceFormMode) => {
   const createMutation = useCreateInterface();
   const updateMutation = useUpdateInterface();
-  return isEdit ? updateMutation : createMutation;
+  return mode === "edit" ? updateMutation : createMutation;
 };
 
 /**

--- a/src/client/src/content/forms/interface/InterfaceForm.tsx
+++ b/src/client/src/content/forms/interface/InterfaceForm.tsx
@@ -1,5 +1,6 @@
 import { DevTool } from "@hookform/devtools";
 import { yupResolver } from "@hookform/resolvers/yup";
+import { InterfaceLibCm } from "@mimirorg/typelibrary-types";
 import { FormProvider, useFieldArray, useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "styled-components";
@@ -22,13 +23,14 @@ import {
   mapFormInterfaceLibToApiModel,
   mapInterfaceLibCmToFormInterfaceLib,
 } from "./types/formInterfaceLib";
+import { InterfaceFormMode } from "./types/interfaceFormMode";
 
 interface InterfaceFormProps {
   defaultValues?: FormInterfaceLib;
-  isEdit?: boolean;
+  mode?: InterfaceFormMode;
 }
 
-export const InterfaceForm = ({ defaultValues = createEmptyFormInterfaceLib(), isEdit }: InterfaceFormProps) => {
+export const InterfaceForm = ({ defaultValues = createEmptyFormInterfaceLib(), mode }: InterfaceFormProps) => {
   const theme = useTheme();
   const { t } = useTranslation();
 
@@ -45,7 +47,7 @@ export const InterfaceForm = ({ defaultValues = createEmptyFormInterfaceLib(), i
   const query = useInterfaceQuery();
   const [isPrefilled, isLoading] = usePrefilledForm(query, mapInterfaceLibCmToFormInterfaceLib, reset);
 
-  const mutation = useInterfaceMutation(isEdit);
+  const mutation = useInterfaceMutation(mode);
   useServerValidation(mutation.error, setError);
   useNavigateOnCriteria("/", mutation.isSuccess);
 

--- a/src/client/src/content/forms/interface/InterfaceForm.tsx
+++ b/src/client/src/content/forms/interface/InterfaceForm.tsx
@@ -45,7 +45,8 @@ export const InterfaceForm = ({ defaultValues = createEmptyFormInterfaceLib(), m
   const attributeFields = useFieldArray({ control, name: "attributeIdList" });
 
   const query = useInterfaceQuery();
-  const [isPrefilled, isLoading] = usePrefilledForm(query, mapInterfaceLibCmToFormInterfaceLib, reset);
+  const mapper = (source: InterfaceLibCm) => mapInterfaceLibCmToFormInterfaceLib(source, mode);
+  const [isPrefilled, isLoading] = usePrefilledForm(query, mapper, reset);
 
   const mutation = useInterfaceMutation(mode);
   useServerValidation(mutation.error, setError);

--- a/src/client/src/content/forms/interface/types/formInterfaceLib.ts
+++ b/src/client/src/content/forms/interface/types/formInterfaceLib.ts
@@ -3,6 +3,7 @@ import { UpdateEntity } from "../../../../data/types/updateEntity";
 import { createEmptyInterfaceLibAm } from "../../../../models/tyle/application/interfaceLibAm";
 import { mapInterfaceLibCmToInterfaceLibAm } from "../../../../utils/mappers";
 import { ValueObject } from "../../types/valueObject";
+import { InterfaceFormMode } from "./interfaceFormMode";
 
 /**
  * This type functions as a layer between client needs and the backend model.
@@ -28,9 +29,13 @@ export const createEmptyFormInterfaceLib = (): FormInterfaceLib => ({
   attributeIdList: [],
 });
 
-export const mapInterfaceLibCmToFormInterfaceLib = (interfaceLibCm: InterfaceLibCm): FormInterfaceLib => ({
+export const mapInterfaceLibCmToFormInterfaceLib = (
+  interfaceLibCm: InterfaceLibCm,
+  mode?: InterfaceFormMode
+): FormInterfaceLib => ({
   ...mapInterfaceLibCmToInterfaceLibAm(interfaceLibCm),
   id: interfaceLibCm.id,
+  parentId: mode === "clone" ? interfaceLibCm.id : interfaceLibCm.parentId,
   attributeIdList: interfaceLibCm.attributes.map((x) => ({
     value: x.id,
   })),

--- a/src/client/src/content/forms/interface/types/interfaceFormMode.ts
+++ b/src/client/src/content/forms/interface/types/interfaceFormMode.ts
@@ -1,0 +1,1 @@
+export type InterfaceFormMode = "edit" | "clone";

--- a/src/client/src/content/forms/node/NodeForm.helpers.tsx
+++ b/src/client/src/content/forms/node/NodeForm.helpers.tsx
@@ -4,16 +4,17 @@ import { useCreateNode, useGetNode, useUpdateNode } from "../../../data/queries/
 import { NodeFormPredefinedAttributes } from "./predefined-attributes/NodeFormPredefinedAttributes";
 import { NodeFormTerminalTable } from "./terminals/NodeFormTerminalTable";
 import { FormNodeLib } from "./types/formNodeLib";
+import { NodeFormMode } from "./types/nodeFormMode";
 
 export const useNodeQuery = () => {
   const { id } = useParams();
   return useGetNode(id);
 };
 
-export const useNodeMutation = (isEdit?: boolean) => {
+export const useNodeMutation = (mode?: NodeFormMode) => {
   const nodeUpdateMutation = useUpdateNode();
   const nodeCreateMutation = useCreateNode();
-  return isEdit ? nodeUpdateMutation : nodeCreateMutation;
+  return mode === "edit" ? nodeUpdateMutation : nodeCreateMutation;
 };
 
 /**

--- a/src/client/src/content/forms/node/NodeForm.tsx
+++ b/src/client/src/content/forms/node/NodeForm.tsx
@@ -1,5 +1,6 @@
 import { DevTool } from "@hookform/devtools";
 import { yupResolver } from "@hookform/resolvers/yup";
+import { NodeLibCm } from "@mimirorg/typelibrary-types";
 import { FormProvider, useFieldArray, useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "styled-components/macro";
@@ -22,13 +23,14 @@ import {
   mapFormNodeLibToApiModel,
   mapNodeLibCmToFormNodeLib,
 } from "./types/formNodeLib";
+import { NodeFormMode } from "./types/nodeFormMode";
 
 interface NodeFormProps {
   defaultValues?: FormNodeLib;
-  isEdit?: boolean;
+  mode?: NodeFormMode;
 }
 
-export const NodeForm = ({ defaultValues = createEmptyFormNodeLib(), isEdit }: NodeFormProps) => {
+export const NodeForm = ({ defaultValues = createEmptyFormNodeLib(), mode }: NodeFormProps) => {
   const theme = useTheme();
   const { t } = useTranslation();
 
@@ -45,7 +47,7 @@ export const NodeForm = ({ defaultValues = createEmptyFormNodeLib(), isEdit }: N
   const query = useNodeQuery();
   const [isPrefilled, isLoading] = usePrefilledForm(query, mapNodeLibCmToFormNodeLib, reset);
 
-  const mutation = useNodeMutation(isEdit);
+  const mutation = useNodeMutation(mode);
   useServerValidation(mutation.error, setError);
   useNavigateOnCriteria("/", mutation.isSuccess);
 

--- a/src/client/src/content/forms/node/NodeForm.tsx
+++ b/src/client/src/content/forms/node/NodeForm.tsx
@@ -45,7 +45,8 @@ export const NodeForm = ({ defaultValues = createEmptyFormNodeLib(), mode }: Nod
   const attributeFields = useFieldArray({ control, name: "attributeIdList" });
 
   const query = useNodeQuery();
-  const [isPrefilled, isLoading] = usePrefilledForm(query, mapNodeLibCmToFormNodeLib, reset);
+  const mapper = (source: NodeLibCm) => mapNodeLibCmToFormNodeLib(source, mode);
+  const [isPrefilled, isLoading] = usePrefilledForm(query, mapper, reset);
 
   const mutation = useNodeMutation(mode);
   useServerValidation(mutation.error, setError);

--- a/src/client/src/content/forms/node/types/formNodeLib.ts
+++ b/src/client/src/content/forms/node/types/formNodeLib.ts
@@ -7,6 +7,7 @@ import {
   FormSelectedAttributePredefinedLib,
   mapFormSelectedAttributePredefinedLibToApiModel,
 } from "./formSelectedAttributePredefinedLib";
+import { NodeFormMode } from "./nodeFormMode";
 
 /**
  * This type functions as a layer between client needs and the backend model.
@@ -36,9 +37,10 @@ export const createEmptyFormNodeLib = (): FormNodeLib => ({
   selectedAttributePredefined: [],
 });
 
-export const mapNodeLibCmToFormNodeLib = (nodeLibCm: NodeLibCm): FormNodeLib => ({
+export const mapNodeLibCmToFormNodeLib = (nodeLibCm: NodeLibCm, mode?: NodeFormMode): FormNodeLib => ({
   ...mapNodeLibCmToNodeLibAm(nodeLibCm),
   id: nodeLibCm.id,
+  parentId: mode === "clone" ? nodeLibCm.id : nodeLibCm.parentId,
   attributeIdList: nodeLibCm.attributes.map((x) => ({
     value: x.id,
   })),

--- a/src/client/src/content/forms/node/types/nodeFormMode.ts
+++ b/src/client/src/content/forms/node/types/nodeFormMode.ts
@@ -1,0 +1,1 @@
+export type NodeFormMode = "edit" | "clone";

--- a/src/client/src/content/forms/terminal/TerminalForm.helpers.ts
+++ b/src/client/src/content/forms/terminal/TerminalForm.helpers.ts
@@ -1,16 +1,17 @@
 import { AttributeLibCm } from "@mimirorg/typelibrary-types";
 import { useParams } from "react-router-dom";
 import { useCreateTerminal, useGetTerminal, useUpdateTerminal } from "../../../data/queries/tyle/queriesTerminal";
+import { TerminalFormMode } from "./types/terminalFormMode";
 
 export const useTerminalQuery = () => {
   const { id } = useParams();
   return useGetTerminal(id);
 };
 
-export const useTerminalMutation = (isEdit?: boolean) => {
+export const useTerminalMutation = (mode?: TerminalFormMode) => {
   const createMutation = useCreateTerminal();
   const updateMutation = useUpdateTerminal();
-  return isEdit ? updateMutation : createMutation;
+  return mode === "edit" ? updateMutation : createMutation;
 };
 
 export const prepareAttributes = (attributes?: AttributeLibCm[]) => {

--- a/src/client/src/content/forms/terminal/TerminalForm.tsx
+++ b/src/client/src/content/forms/terminal/TerminalForm.tsx
@@ -1,5 +1,6 @@
 import { DevTool } from "@hookform/devtools";
 import { yupResolver } from "@hookform/resolvers/yup";
+import { TerminalLibCm } from "@mimirorg/typelibrary-types";
 import { FormProvider, useFieldArray, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "styled-components";
@@ -21,13 +22,14 @@ import {
   mapFormTerminalLibToApiModel,
   mapTerminalLibCmToFormTerminalLib,
 } from "./types/formTerminalLib";
+import { TerminalFormMode } from "./types/terminalFormMode";
 
 interface TerminalFormProps {
   defaultValues?: FormTerminalLib;
-  isEdit?: boolean;
+  mode?: TerminalFormMode;
 }
 
-export const TerminalForm = ({ defaultValues = createEmptyFormTerminalLib(), isEdit }: TerminalFormProps) => {
+export const TerminalForm = ({ defaultValues = createEmptyFormTerminalLib(), mode }: TerminalFormProps) => {
   const theme = useTheme();
   const { t } = useTranslation();
 
@@ -43,7 +45,7 @@ export const TerminalForm = ({ defaultValues = createEmptyFormTerminalLib(), isE
   const query = useTerminalQuery();
   const [_, isLoading] = usePrefilledForm(query, mapTerminalLibCmToFormTerminalLib, reset);
 
-  const mutation = useTerminalMutation(isEdit);
+  const mutation = useTerminalMutation(mode);
   useServerValidation(mutation.error, setError);
   useNavigateOnCriteria("/", mutation.isSuccess);
 

--- a/src/client/src/content/forms/terminal/TerminalForm.tsx
+++ b/src/client/src/content/forms/terminal/TerminalForm.tsx
@@ -43,7 +43,8 @@ export const TerminalForm = ({ defaultValues = createEmptyFormTerminalLib(), mod
   const attributeFields = useFieldArray({ control, name: "attributeIdList" });
 
   const query = useTerminalQuery();
-  const [_, isLoading] = usePrefilledForm(query, mapTerminalLibCmToFormTerminalLib, reset);
+  const mapper = (source: TerminalLibCm) => mapTerminalLibCmToFormTerminalLib(source, mode);
+  const [_, isLoading] = usePrefilledForm(query, mapper, reset);
 
   const mutation = useTerminalMutation(mode);
   useServerValidation(mutation.error, setError);

--- a/src/client/src/content/forms/terminal/types/formTerminalLib.ts
+++ b/src/client/src/content/forms/terminal/types/formTerminalLib.ts
@@ -3,6 +3,7 @@ import { UpdateEntity } from "../../../../data/types/updateEntity";
 import { createEmptyTerminalLibAm } from "../../../../models/tyle/application/terminalLibAm";
 import { mapTerminalLibCmToTerminalLibAm } from "../../../../utils/mappers";
 import { ValueObject } from "../../types/valueObject";
+import { TerminalFormMode } from "./terminalFormMode";
 
 /**
  * This type functions as a layer between client needs and the backend model.
@@ -28,9 +29,13 @@ export const createEmptyFormTerminalLib = (): FormTerminalLib => ({
   color: "#f7f6ff",
 });
 
-export const mapTerminalLibCmToFormTerminalLib = (terminalLibCm: TerminalLibCm): FormTerminalLib => ({
+export const mapTerminalLibCmToFormTerminalLib = (
+  terminalLibCm: TerminalLibCm,
+  mode?: TerminalFormMode
+): FormTerminalLib => ({
   ...mapTerminalLibCmToTerminalLibAm(terminalLibCm),
   id: terminalLibCm.id,
+  parentId: mode === "clone" ? terminalLibCm.id : terminalLibCm.parentId,
   attributeIdList: terminalLibCm.attributes.map((x) => ({
     value: x.id,
   })),

--- a/src/client/src/content/forms/terminal/types/terminalFormMode.ts
+++ b/src/client/src/content/forms/terminal/types/terminalFormMode.ts
@@ -1,0 +1,1 @@
+export type TerminalFormMode = "edit" | "clone";

--- a/src/client/src/content/forms/transport/TransportForm.helpers.ts
+++ b/src/client/src/content/forms/transport/TransportForm.helpers.ts
@@ -1,16 +1,17 @@
 import { useParams } from "react-router-dom";
 import { useCreateTransport, useGetTransport, useUpdateTransport } from "../../../data/queries/tyle/queriesTransport";
 import { FormTransportLib } from "./types/formTransportLib";
+import { TransportFormMode } from "./types/transportFormMode";
 
 export const useTransportQuery = () => {
   const { id } = useParams();
   return useGetTransport(id);
 };
 
-export const useTransportMutation = (isEdit?: boolean) => {
+export const useTransportMutation = (mode?: TransportFormMode) => {
   const createMutation = useCreateTransport();
   const updateMutation = useUpdateTransport();
-  return isEdit ? updateMutation : createMutation;
+  return mode === "edit" ? updateMutation : createMutation;
 };
 
 /**

--- a/src/client/src/content/forms/transport/TransportForm.tsx
+++ b/src/client/src/content/forms/transport/TransportForm.tsx
@@ -45,7 +45,8 @@ export const TransportForm = ({ defaultValues = createEmptyFormTransportLib(), m
   const attributeFields = useFieldArray({ control, name: "attributeIdList" });
 
   const query = useTransportQuery();
-  const [isPrefilled, isLoading] = usePrefilledForm(query, mapTransportLibCmToFormTransportLib, reset);
+  const mapper = (source: TransportLibCm) => mapTransportLibCmToFormTransportLib(source, mode);
+  const [isPrefilled, isLoading] = usePrefilledForm(query, mapper, reset);
 
   const mutation = useTransportMutation(mode);
   useServerValidation(mutation.error, setError);

--- a/src/client/src/content/forms/transport/TransportForm.tsx
+++ b/src/client/src/content/forms/transport/TransportForm.tsx
@@ -1,5 +1,6 @@
 import { DevTool } from "@hookform/devtools";
 import { yupResolver } from "@hookform/resolvers/yup";
+import { TransportLibCm } from "@mimirorg/typelibrary-types";
 import { FormProvider, useFieldArray, useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "styled-components";
@@ -22,13 +23,14 @@ import {
   mapFormTransportLibToApiModel,
   mapTransportLibCmToFormTransportLib,
 } from "./types/formTransportLib";
+import { TransportFormMode } from "./types/transportFormMode";
 
 interface TransportFormProps {
   defaultValues?: FormTransportLib;
-  isEdit?: boolean;
+  mode?: TransportFormMode;
 }
 
-export const TransportForm = ({ defaultValues = createEmptyFormTransportLib(), isEdit }: TransportFormProps) => {
+export const TransportForm = ({ defaultValues = createEmptyFormTransportLib(), mode }: TransportFormProps) => {
   const theme = useTheme();
   const { t } = useTranslation();
 
@@ -45,7 +47,7 @@ export const TransportForm = ({ defaultValues = createEmptyFormTransportLib(), i
   const query = useTransportQuery();
   const [isPrefilled, isLoading] = usePrefilledForm(query, mapTransportLibCmToFormTransportLib, reset);
 
-  const mutation = useTransportMutation(isEdit);
+  const mutation = useTransportMutation(mode);
   useServerValidation(mutation.error, setError);
   useNavigateOnCriteria("/", mutation.isSuccess);
 

--- a/src/client/src/content/forms/transport/types/formTransportLib.ts
+++ b/src/client/src/content/forms/transport/types/formTransportLib.ts
@@ -3,6 +3,7 @@ import { UpdateEntity } from "../../../../data/types/updateEntity";
 import { createEmptyTransportLibAm } from "../../../../models/tyle/application/transportLibAm";
 import { mapTransportLibCmToTransportLibAm } from "../../../../utils/mappers";
 import { ValueObject } from "../../types/valueObject";
+import { TransportFormMode } from "./transportFormMode";
 
 /**
  * This type functions as a layer between client needs and the backend model.
@@ -28,9 +29,13 @@ export const createEmptyFormTransportLib = (): FormTransportLib => ({
   attributeIdList: [],
 });
 
-export const mapTransportLibCmToFormTransportLib = (transportLibCm: TransportLibCm): FormTransportLib => ({
+export const mapTransportLibCmToFormTransportLib = (
+  transportLibCm: TransportLibCm,
+  mode?: TransportFormMode
+): FormTransportLib => ({
   ...mapTransportLibCmToTransportLibAm(transportLibCm),
   id: transportLibCm.id,
+  parentId: mode === "clone" ? transportLibCm.id : transportLibCm.parentId,
   attributeIdList: transportLibCm.attributes.map((x) => ({
     value: x.id,
   })),

--- a/src/client/src/content/forms/transport/types/transportFormMode.ts
+++ b/src/client/src/content/forms/transport/types/transportFormMode.ts
@@ -1,0 +1,1 @@
+export type TransportFormMode = "edit" | "clone";


### PR DESCRIPTION
# Clone inheritance

## Goals 🎯
- https://github.com/mimir-org/typelibrary/issues/155
- Support inheritance through the client's clone action
- Find a flexible approach to defining a form's "mode" (clone, edit etc..)

## Noteworthy changes
- [refactor(client): replaces isEdit flag with mode type](https://github.com/mimir-org/typelibrary/commit/a71fc9db0b5e0134c7473e60823cbbad9601a8fd)
- [feat(client): adds mapping of id to parentId when cloning](https://github.com/mimir-org/typelibrary/commit/2d5bf903a0b21e751cda7f49dad4a80371c12c42)

## Demo 📸

### Form mode
![image](https://user-images.githubusercontent.com/21368234/191730321-ad6a1392-599c-4235-af5c-ce29fe72fce6.png)

### Form mapper (prefilled data)
![image](https://user-images.githubusercontent.com/21368234/191730430-7ca319ec-40ee-41a2-b6bd-219d8b5e6453.png)