### PR TITLE
Feature/tests

### DIFF
--- a/src/server/Mimirorg.Authentication/Mimirorg.Authentication.csproj
+++ b/src/server/Mimirorg.Authentication/Mimirorg.Authentication.csproj
@@ -8,12 +8,12 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.Totp" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.10" />
     <PackageReference Include="Microsoft.Identity.Web" Version="1.25.3" />
     <PackageReference Include="SendGrid" Version="9.28.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />

--- a/src/server/Mimirorg.Common/Extensions/EnumerableExtensions.cs
+++ b/src/server/Mimirorg.Common/Extensions/EnumerableExtensions.cs
@@ -17,11 +17,36 @@ namespace Mimirorg.Common.Extensions
             return dictA.Keys.Union(dictB.Keys).ToDictionary(k => k, k => dictA.ContainsKey(k) ? dictA[k] : dictB[k]);
         }
 
-        public static IEnumerable<T> LatestVersion<T>(this IEnumerable<T> collection, bool includeDeleted = false) where T : IVersionObject
+        public static IEnumerable<T> LatestVersionsExcludeDeleted<T>(this IEnumerable<T> collection) where T : IVersionObject
         {
-            return includeDeleted 
-                ? collection.OrderByDescending(x => double.Parse(x.Version, CultureInfo.InvariantCulture)).DistinctBy(x => x.FirstVersionId) 
-                : collection.Where(x => x.State != State.Deleted).OrderByDescending(x => double.Parse(x.Version, CultureInfo.InvariantCulture)).DistinctBy(x => x.FirstVersionId);
+            return collection
+                .Where(x => x.State != State.Deleted)
+                .OrderByDescending(x => double.Parse(x.Version, CultureInfo.InvariantCulture))
+                .DistinctBy(x => x.FirstVersionId);
         }
+
+        public static IEnumerable<T> LatestVersionsIncludeDeleted<T>(this IEnumerable<T> collection) where T : IVersionObject
+        {
+            return collection
+                .OrderByDescending(x => double.Parse(x.Version, CultureInfo.InvariantCulture))
+                .DistinctBy(x => x.FirstVersionId);
+        }
+
+        public static T LatestVersionExcludeDeleted<T>(this IEnumerable<T> collection, string firstVersionId) where T : IVersionObject
+        {
+            return collection
+                .Where(x => x.FirstVersionId == firstVersionId && x.State != State.Deleted)
+                .OrderByDescending(x => double.Parse(x.Version, CultureInfo.InvariantCulture))
+                .FirstOrDefault();
+        }
+
+        public static T LatestVersionIncludeDeleted<T>(this IEnumerable<T> collection, string firstVersionId) where T : IVersionObject
+        {
+            return collection
+                .Where(x => x.FirstVersionId == firstVersionId)
+                .OrderByDescending(x => double.Parse(x.Version, CultureInfo.InvariantCulture))
+                .FirstOrDefault();
+        }
+
     }
 }

--- a/src/server/Mimirorg.Common/Extensions/EnumerableExtensions.cs
+++ b/src/server/Mimirorg.Common/Extensions/EnumerableExtensions.cs
@@ -17,9 +17,11 @@ namespace Mimirorg.Common.Extensions
             return dictA.Keys.Union(dictB.Keys).ToDictionary(k => k, k => dictA.ContainsKey(k) ? dictA[k] : dictB[k]);
         }
 
-        public static IEnumerable<T> LatestVersion<T>(this IEnumerable<T> collection) where T : IVersionObject
+        public static IEnumerable<T> LatestVersion<T>(this IEnumerable<T> collection, bool includeDeleted = false) where T : IVersionObject
         {
-            return collection.Where(x => x.State != State.Deleted).OrderByDescending(x => double.Parse(x.Version, CultureInfo.InvariantCulture)).DistinctBy(x => x.FirstVersionId);
+            return includeDeleted 
+                ? collection.OrderByDescending(x => double.Parse(x.Version, CultureInfo.InvariantCulture)).DistinctBy(x => x.FirstVersionId) 
+                : collection.Where(x => x.State != State.Deleted).OrderByDescending(x => double.Parse(x.Version, CultureInfo.InvariantCulture)).DistinctBy(x => x.FirstVersionId);
         }
     }
 }

--- a/src/server/Mimirorg.Common/Mimirorg.Common.csproj
+++ b/src/server/Mimirorg.Common/Mimirorg.Common.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.10" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.23.1" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.24.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
   </ItemGroup>

--- a/src/server/Mimirorg.Common/Mimirorg.Common.csproj
+++ b/src/server/Mimirorg.Common/Mimirorg.Common.csproj
@@ -7,9 +7,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.10" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.23.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />

--- a/src/server/Tests/Mimirorg.Integration.Tests/Mimirorg.Integration.Tests.csproj
+++ b/src/server/Tests/Mimirorg.Integration.Tests/Mimirorg.Integration.Tests.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.9" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.9" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.9" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.10" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/src/server/Tests/Mimirorg.Integration.Tests/Services/AttributeServiceTests.cs
+++ b/src/server/Tests/Mimirorg.Integration.Tests/Services/AttributeServiceTests.cs
@@ -69,7 +69,7 @@ namespace Mimirorg.Integration.Tests.Services
         {
             using var scope = Factory.Server.Services.CreateScope();
             var attributeService = scope.ServiceProvider.GetRequiredService<IAttributeService>();
-
+            
             var rangeSpecifying = await attributeService.GetQuantityDatumRangeSpecifying();
             var regularitySpecified = await attributeService.GetQuantityDatumRegularitySpecified();
             var specifiedProvenance = await attributeService.GetQuantityDatumSpecifiedProvenance();
@@ -92,6 +92,7 @@ namespace Mimirorg.Integration.Tests.Services
             using var scope = Factory.Server.Services.CreateScope();
             var attributeService = scope.ServiceProvider.GetRequiredService<IAttributeService>();
             var unitService = scope.ServiceProvider.GetRequiredService<IUnitService>();
+            var logService = scope.ServiceProvider.GetRequiredService<ILogService>();
             var units = (await unitService.Get()).ToList();
 
             Assert.True(units != null);
@@ -167,6 +168,20 @@ namespace Mimirorg.Integration.Tests.Services
 
             for (var i = 0; i < amUnitIdList.Count; i++)
                 Assert.Equal(amUnitIdList[i], cmUnitIdList[i]);
+
+            var logCm = logService.Get().FirstOrDefault(x => x.ObjectId == attributeCm.Id);
+
+            Assert.True(logCm != null);
+            Assert.Equal(attributeCm.Id, logCm.ObjectId);
+            Assert.Equal(attributeCm.FirstVersionId, logCm.ObjectFirstVersionId);
+            Assert.Equal(attributeCm.Name, logCm.ObjectName);
+            Assert.Equal(attributeCm.Version, logCm.ObjectVersion);
+            Assert.Equal(attributeCm.GetType().Name.Remove(attributeCm.GetType().Name.Length - 2, 2) + "Dm", logCm.ObjectType);
+            Assert.Equal(LogType.State.ToString(), logCm.LogType.ToString());
+            Assert.Equal(State.Draft.ToString(), logCm.LogTypeValue);
+            Assert.NotNull(logCm.User);
+            Assert.Equal("System.DateTime", logCm.Created.GetType().ToString());
+            Assert.True(logCm.Created.Kind == DateTimeKind.Utc);
         }
 
         [Fact]

--- a/src/server/Tests/Mimirorg.Integration.Tests/Services/AttributeServiceTests.cs
+++ b/src/server/Tests/Mimirorg.Integration.Tests/Services/AttributeServiceTests.cs
@@ -69,7 +69,7 @@ namespace Mimirorg.Integration.Tests.Services
         {
             using var scope = Factory.Server.Services.CreateScope();
             var attributeService = scope.ServiceProvider.GetRequiredService<IAttributeService>();
-            
+
             var rangeSpecifying = await attributeService.GetQuantityDatumRangeSpecifying();
             var regularitySpecified = await attributeService.GetQuantityDatumRegularitySpecified();
             var specifiedProvenance = await attributeService.GetQuantityDatumSpecifiedProvenance();

--- a/src/server/Tests/Mimirorg.Integration.Tests/Services/InterfaceServiceTests.cs
+++ b/src/server/Tests/Mimirorg.Integration.Tests/Services/InterfaceServiceTests.cs
@@ -53,6 +53,7 @@ namespace Mimirorg.Integration.Tests.Services
             var interfaceService = Factory.Server.Services.CreateScope().ServiceProvider.GetRequiredService<IInterfaceService>();
             var attributeService = Factory.Server.Services.CreateScope().ServiceProvider.GetRequiredService<IAttributeService>();
             var terminalService = Factory.Server.Services.CreateScope().ServiceProvider.GetRequiredService<ITerminalService>();
+            var logService = Factory.Server.Services.CreateScope().ServiceProvider.GetRequiredService<ILogService>();
 
             var attributeAm = new AttributeLibAm
             {
@@ -149,6 +150,20 @@ namespace Mimirorg.Integration.Tests.Services
             Assert.Equal(interfaceAm.TypeReferences.First().Subs.First().Name, interfaceCm.TypeReferences.First().Subs.First().Name);
             Assert.Equal(interfaceAm.TypeReferences.First().Subs.First().Iri, interfaceCm.TypeReferences.First().Subs.First().Iri);
             Assert.Equal(interfaceAm.ParentId, interfaceCm.ParentId);
+
+            var logCm = logService.Get().FirstOrDefault(x => x.ObjectId == interfaceCm.Id);
+
+            Assert.True(logCm != null);
+            Assert.Equal(interfaceCm.Id, logCm.ObjectId);
+            Assert.Equal(interfaceCm.FirstVersionId, logCm.ObjectFirstVersionId);
+            Assert.Equal(interfaceCm.Name, logCm.ObjectName);
+            Assert.Equal(interfaceCm.Version, logCm.ObjectVersion);
+            Assert.Equal(interfaceCm.GetType().Name.Remove(interfaceCm.GetType().Name.Length - 2, 2) + "Dm", logCm.ObjectType);
+            Assert.Equal(LogType.State.ToString(), logCm.LogType.ToString());
+            Assert.Equal(State.Draft.ToString(), logCm.LogTypeValue);
+            Assert.NotNull(logCm.User);
+            Assert.Equal("System.DateTime", logCm.Created.GetType().ToString());
+            Assert.True(logCm.Created.Kind == DateTimeKind.Utc);
         }
 
         [Fact]

--- a/src/server/Tests/Mimirorg.Integration.Tests/Services/NodeServiceTests.cs
+++ b/src/server/Tests/Mimirorg.Integration.Tests/Services/NodeServiceTests.cs
@@ -43,6 +43,7 @@ namespace Mimirorg.Integration.Tests.Services
         {
             var nodeService = Factory.Server.Services.CreateScope().ServiceProvider.GetRequiredService<INodeService>();
             var attributeService = Factory.Server.Services.CreateScope().ServiceProvider.GetRequiredService<IAttributeService>();
+            var logService = Factory.Server.Services.CreateScope().ServiceProvider.GetRequiredService<ILogService>();
 
             var attributeAm = new AttributeLibAm
             {
@@ -172,6 +173,20 @@ namespace Mimirorg.Integration.Tests.Services
 
             Assert.Equal(nodeAm.Symbol, nodeCm.Symbol);
             Assert.Equal(nodeAm.ParentId, nodeCm.ParentId);
+
+            var logCm = logService.Get().FirstOrDefault(x => x.ObjectId == nodeCm.Id);
+
+            Assert.True(logCm != null);
+            Assert.Equal(nodeCm.Id, logCm.ObjectId);
+            Assert.Equal(nodeCm.FirstVersionId, logCm.ObjectFirstVersionId);
+            Assert.Equal(nodeCm.Name, logCm.ObjectName);
+            Assert.Equal(nodeCm.Version, logCm.ObjectVersion);
+            Assert.Equal(nodeCm.GetType().Name.Remove(nodeCm.GetType().Name.Length - 2, 2) + "Dm", logCm.ObjectType);
+            Assert.Equal(LogType.State.ToString(), logCm.LogType.ToString());
+            Assert.Equal(State.Draft.ToString(), logCm.LogTypeValue);
+            Assert.NotNull(logCm.User);
+            Assert.Equal("System.DateTime", logCm.Created.GetType().ToString());
+            Assert.True(logCm.Created.Kind == DateTimeKind.Utc);
         }
 
         [Fact]

--- a/src/server/Tests/Mimirorg.Integration.Tests/Services/TerminalServiceTests.cs
+++ b/src/server/Tests/Mimirorg.Integration.Tests/Services/TerminalServiceTests.cs
@@ -73,7 +73,7 @@ namespace Mimirorg.Integration.Tests.Services
 
             var terminalService = Factory.Server.Services.CreateScope().ServiceProvider.GetRequiredService<ITerminalService>();
             var logService = Factory.Server.Services.CreateScope().ServiceProvider.GetRequiredService<ILogService>();
-            
+
             var terminalCm = await terminalService.Create(terminalAm);
 
             Assert.NotNull(terminalCm);

--- a/src/server/Tests/Mimirorg.Integration.Tests/Services/TerminalServiceTests.cs
+++ b/src/server/Tests/Mimirorg.Integration.Tests/Services/TerminalServiceTests.cs
@@ -2,10 +2,12 @@ using Microsoft.Extensions.DependencyInjection;
 using Mimirorg.Common.Enums;
 using Mimirorg.Common.Exceptions;
 using Mimirorg.Setup;
+using Mimirorg.TypeLibrary.Enums;
 using Mimirorg.TypeLibrary.Extensions;
 using Mimirorg.TypeLibrary.Models.Application;
 using Mimirorg.TypeLibrary.Models.Client;
 using TypeLibrary.Services.Contracts;
+using TypeLibrary.Services.Services;
 using Xunit;
 
 namespace Mimirorg.Integration.Tests.Services
@@ -70,6 +72,8 @@ namespace Mimirorg.Integration.Tests.Services
             };
 
             var terminalService = Factory.Server.Services.CreateScope().ServiceProvider.GetRequiredService<ITerminalService>();
+            var logService = Factory.Server.Services.CreateScope().ServiceProvider.GetRequiredService<ILogService>();
+            
             var terminalCm = await terminalService.Create(terminalAm);
 
             Assert.NotNull(terminalCm);
@@ -88,6 +92,20 @@ namespace Mimirorg.Integration.Tests.Services
             Assert.Equal(terminalAm.Description, terminalCm.Description);
             Assert.Equal(terminalAm.AttributeIdList.ToList().ConvertToString(), terminalCm.Attributes.Select(x => x.Id).ToList().ConvertToString());
             Assert.Equal(terminalAm.CompanyId, terminalCm.CompanyId);
+
+            var logCm = logService.Get().FirstOrDefault(x => x.ObjectId == terminalCm.Id);
+
+            Assert.True(logCm != null);
+            Assert.Equal(terminalCm.Id, logCm.ObjectId);
+            Assert.Equal(terminalCm.FirstVersionId, logCm.ObjectFirstVersionId);
+            Assert.Equal(terminalCm.Name, logCm.ObjectName);
+            Assert.Equal(terminalCm.Version, logCm.ObjectVersion);
+            Assert.Equal(terminalCm.GetType().Name.Remove(terminalCm.GetType().Name.Length - 2, 2) + "Dm", logCm.ObjectType);
+            Assert.Equal(LogType.State.ToString(), logCm.LogType.ToString());
+            Assert.Equal(State.Draft.ToString(), logCm.LogTypeValue);
+            Assert.NotNull(logCm.User);
+            Assert.Equal("System.DateTime", logCm.Created.GetType().ToString());
+            Assert.True(logCm.Created.Kind == DateTimeKind.Utc);
         }
 
         [Fact]

--- a/src/server/Tests/Mimirorg.Integration.Tests/Services/TransportServiceTests.cs
+++ b/src/server/Tests/Mimirorg.Integration.Tests/Services/TransportServiceTests.cs
@@ -7,6 +7,7 @@ using Mimirorg.TypeLibrary.Extensions;
 using Mimirorg.TypeLibrary.Models.Application;
 using Mimirorg.TypeLibrary.Models.Client;
 using TypeLibrary.Services.Contracts;
+using TypeLibrary.Services.Services;
 using Xunit;
 
 namespace Mimirorg.Integration.Tests.Services
@@ -125,6 +126,21 @@ namespace Mimirorg.Integration.Tests.Services
             Assert.Equal(transportAm.TypeReferences.First().Subs.First().Name, transportCm.TypeReferences.First().Subs.First().Name);
             Assert.Equal(transportAm.TypeReferences.First().Subs.First().Iri, transportCm.TypeReferences.First().Subs.First().Iri);
             Assert.Equal(transportAm.ParentId, transportCm.ParentId);
+
+            var logService = Factory.Server.Services.CreateScope().ServiceProvider.GetRequiredService<ILogService>();
+            var logCm = logService.Get().FirstOrDefault(x => x.ObjectId == transportCm.Id);
+
+            Assert.True(logCm != null);
+            Assert.Equal(transportCm.Id, logCm.ObjectId);
+            Assert.Equal(transportCm.FirstVersionId, logCm.ObjectFirstVersionId);
+            Assert.Equal(transportCm.Name, logCm.ObjectName);
+            Assert.Equal(transportCm.Version, logCm.ObjectVersion);
+            Assert.Equal(transportCm.GetType().Name.Remove(transportCm.GetType().Name.Length - 2, 2) + "Dm", logCm.ObjectType);
+            Assert.Equal(LogType.State.ToString(), logCm.LogType.ToString());
+            Assert.Equal(State.Draft.ToString(), logCm.LogTypeValue);
+            Assert.NotNull(logCm.User);
+            Assert.Equal("System.DateTime", logCm.Created.GetType().ToString());
+            Assert.True(logCm.Created.Kind == DateTimeKind.Utc);
         }
 
         [Fact]

--- a/src/server/Tests/Mimirorg.Setup/Mimirorg.Setup.csproj
+++ b/src/server/Tests/Mimirorg.Setup/Mimirorg.Setup.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.9" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.9" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.9" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.10" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
         <PackageReference Include="Moq" Version="4.18.2" />
         <PackageReference Include="xunit" Version="2.4.2" />

--- a/src/server/Tests/Mimirorg.Unit.Tests/Extensions/EnumerableExtensionTests.cs
+++ b/src/server/Tests/Mimirorg.Unit.Tests/Extensions/EnumerableExtensionTests.cs
@@ -58,7 +58,7 @@ namespace Mimirorg.Unit.Tests.Extensions
                 }
             };
 
-            var latest = list.LatestVersion().ToList();
+            var latest = list.LatestVersionsExcludeDeleted().ToList();
             Assert.Equal(2, latest.Count);
             Assert.NotNull(latest.FirstOrDefault(x => x.FirstVersionId == "123" && x.Version == "3.0"));
             Assert.NotNull(latest.FirstOrDefault(x => x.FirstVersionId == "567" && x.Version == "1.0"));

--- a/src/server/TypeLibrary.Api/TypeLibrary.Api.csproj
+++ b/src/server/TypeLibrary.Api/TypeLibrary.Api.csproj
@@ -17,14 +17,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.9">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.10" />
     <PackageReference Include="Microsoft.Identity.Web" Version="1.25.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />

--- a/src/server/TypeLibrary.Core/TypeLibrary.Core.csproj
+++ b/src/server/TypeLibrary.Core/TypeLibrary.Core.csproj
@@ -9,16 +9,16 @@
     <PackageReference Include="DelegateDecompiler.EntityFramework" Version="0.30.0" />
     <PackageReference Include="MailKit" Version="3.4.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.9">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.10" />
     <PackageReference Include="MimeKit" Version="3.4.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />

--- a/src/server/TypeLibrary.Data/TypeLibrary.Data.csproj
+++ b/src/server/TypeLibrary.Data/TypeLibrary.Data.csproj
@@ -9,10 +9,10 @@
     <PackageReference Include="AutoMapper" Version="12.0.0" />
     <PackageReference Include="dotNetRDF" Version="2.7.5" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.10" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/src/server/TypeLibrary.Services/Services/AttributeService.cs
+++ b/src/server/TypeLibrary.Services/Services/AttributeService.cs
@@ -180,16 +180,8 @@ namespace TypeLibrary.Services.Services
             if (dm == null)
                 throw new MimirorgNotFoundException($"Attribute with id {id} not found, or is not latest version.");
 
-            var newStateDms = _attributeRepository.Get().Where(x => x.FirstVersionId == dm.FirstVersionId && x.State != state).ToList();
-
-            if (!newStateDms.Any())
-                return null;
-
-            await _attributeRepository.ChangeState(state, newStateDms.Select(x => x.Id).ToList());
-
-            foreach (var newStateDm in newStateDms)
-                await _logService.CreateLog(newStateDm, LogType.State, state.ToString());
-
+            await _attributeRepository.ChangeState(state, new List<string>{ dm.Id });
+            await _logService.CreateLog(dm, LogType.State, state.ToString());
             _hookService.HookQueue.Enqueue(CacheKey.Attribute);
 
             return state == State.Deleted ? null : GetLatestVersion(id);

--- a/src/server/TypeLibrary.Services/Services/AttributeService.cs
+++ b/src/server/TypeLibrary.Services/Services/AttributeService.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using AutoMapper;
@@ -150,7 +149,7 @@ namespace TypeLibrary.Services.Services
             //We need to take into account that there exist a higher version that has state 'Deleted'.
             //Therefore we need to increment minor/major from the latest version, including those with state 'Deleted'.
             attributeToUpdate.Version = _attributeRepository.Get().LatestVersionIncludeDeleted(attributeToUpdate.FirstVersionId).Version;
-            
+
             attributeAm.Version = versionStatus switch
             {
                 VersionStatus.Minor => attributeToUpdate.Version.IncrementMinorVersion(),
@@ -185,7 +184,7 @@ namespace TypeLibrary.Services.Services
             if (dm == null)
                 throw new MimirorgNotFoundException($"Attribute with id {id} not found, or is not latest version.");
 
-            await _attributeRepository.ChangeState(state, new List<string>{ dm.Id });
+            await _attributeRepository.ChangeState(state, new List<string> { dm.Id });
             await _logService.CreateLog(dm, LogType.State, state.ToString());
             _hookService.HookQueue.Enqueue(CacheKey.Attribute);
 

--- a/src/server/TypeLibrary.Services/Services/InterfaceService.cs
+++ b/src/server/TypeLibrary.Services/Services/InterfaceService.cs
@@ -171,16 +171,8 @@ namespace TypeLibrary.Services.Services
             if (dm == null)
                 throw new MimirorgNotFoundException($"Interface with id {id} not found, or is not latest version.");
 
-            var newStateDms = _interfaceRepository.Get().Where(x => x.FirstVersionId == dm.FirstVersionId && x.State != state).ToList();
-
-            if (!newStateDms.Any())
-                return null;
-
-            await _interfaceRepository.ChangeState(state, newStateDms.Select(x => x.Id).ToList());
-
-            foreach (var newStateDm in newStateDms)
-                await _logService.CreateLog(newStateDm, LogType.State, state.ToString());
-
+            await _interfaceRepository.ChangeState(state, new List<string> { dm.Id });
+            await _logService.CreateLog(dm, LogType.State, state.ToString());
             _hookService.HookQueue.Enqueue(CacheKey.Interface);
 
             return state == State.Deleted ? null : GetLatestVersion(id);

--- a/src/server/TypeLibrary.Services/Services/InterfaceService.cs
+++ b/src/server/TypeLibrary.Services/Services/InterfaceService.cs
@@ -13,7 +13,6 @@ using Mimirorg.TypeLibrary.Models.Application;
 using Mimirorg.TypeLibrary.Models.Client;
 using TypeLibrary.Data.Contracts;
 using TypeLibrary.Data.Models;
-using TypeLibrary.Data.Repositories.Ef;
 using TypeLibrary.Services.Contracts;
 
 namespace TypeLibrary.Services.Services

--- a/src/server/TypeLibrary.Services/Services/LogService.cs
+++ b/src/server/TypeLibrary.Services/Services/LogService.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/server/TypeLibrary.Services/Services/NodeService.cs
+++ b/src/server/TypeLibrary.Services/Services/NodeService.cs
@@ -171,16 +171,8 @@ namespace TypeLibrary.Services.Services
             if (dm == null)
                 throw new MimirorgNotFoundException($"Node with id {id} not found, or is not latest version.");
 
-            var newStateDms = _nodeRepository.Get().Where(x => x.FirstVersionId == dm.FirstVersionId && x.State != state).ToList();
-
-            if (!newStateDms.Any())
-                return null;
-
-            await _nodeRepository.ChangeState(state, newStateDms.Select(x => x.Id).ToList());
-
-            foreach (var newStateDm in newStateDms)
-                await _logService.CreateLog(newStateDm, LogType.State, state.ToString());
-
+            await _nodeRepository.ChangeState(state, new List<string> { dm.Id });
+            await _logService.CreateLog(dm, LogType.State, state.ToString());
             _hookService.HookQueue.Enqueue(CacheKey.AspectNode);
 
             return state == State.Deleted ? null : GetLatestVersion(id);

--- a/src/server/TypeLibrary.Services/Services/TerminalService.cs
+++ b/src/server/TypeLibrary.Services/Services/TerminalService.cs
@@ -170,16 +170,8 @@ namespace TypeLibrary.Services.Services
             if (dm == null)
                 throw new MimirorgNotFoundException($"Terminal with id {id} not found, or is not latest version.");
 
-            var newStateDms = _terminalRepository.Get().Where(x => x.FirstVersionId == dm.FirstVersionId && x.State != state).ToList();
-
-            if (!newStateDms.Any())
-                return null;
-
-            await _terminalRepository.ChangeState(state, newStateDms.Select(x => x.Id).ToList());
-
-            foreach (var newStateDm in newStateDms)
-                await _logService.CreateLog(newStateDm, LogType.State, state.ToString());
-
+            await _terminalRepository.ChangeState(state, new List<string> { dm.Id });
+            await _logService.CreateLog(dm, LogType.State, state.ToString());
             _hookService.HookQueue.Enqueue(CacheKey.Terminal);
 
             return state == State.Deleted ? null : GetLatestVersion(id);

--- a/src/server/TypeLibrary.Services/Services/TransportService.cs
+++ b/src/server/TypeLibrary.Services/Services/TransportService.cs
@@ -13,7 +13,6 @@ using Mimirorg.TypeLibrary.Models.Application;
 using Mimirorg.TypeLibrary.Models.Client;
 using TypeLibrary.Data.Contracts;
 using TypeLibrary.Data.Models;
-using TypeLibrary.Data.Repositories.Ef;
 using TypeLibrary.Services.Contracts;
 
 namespace TypeLibrary.Services.Services
@@ -151,7 +150,7 @@ namespace TypeLibrary.Services.Services
 
             dm.State = State.Draft;
             dm.FirstVersionId = transportToUpdate.FirstVersionId;
-            
+
             await _transportRepository.Create(dm);
             _transportRepository.ClearAllChangeTrackers();
             await _transportRepository.ChangeParentId(transportAm.Id, dm.Id);

--- a/src/server/TypeLibrary.Services/Services/TransportService.cs
+++ b/src/server/TypeLibrary.Services/Services/TransportService.cs
@@ -13,6 +13,7 @@ using Mimirorg.TypeLibrary.Models.Application;
 using Mimirorg.TypeLibrary.Models.Client;
 using TypeLibrary.Data.Contracts;
 using TypeLibrary.Data.Models;
+using TypeLibrary.Data.Repositories.Ef;
 using TypeLibrary.Services.Contracts;
 
 namespace TypeLibrary.Services.Services
@@ -40,7 +41,7 @@ namespace TypeLibrary.Services.Services
         /// <exception cref="MimirorgNotFoundException">Throws if there is no transport with the given id, and that transport is at the latest version.</exception>
         public TransportLibCm GetLatestVersion(string id)
         {
-            var dm = _transportRepository.Get().LatestVersion().FirstOrDefault(x => x.Id == id);
+            var dm = _transportRepository.Get().LatestVersionsExcludeDeleted().FirstOrDefault(x => x.Id == id);
 
             if (dm == null)
                 throw new MimirorgNotFoundException($"Transport with id {id} not found.");
@@ -54,7 +55,7 @@ namespace TypeLibrary.Services.Services
         /// <returns>A collection of transport</returns>
         public IEnumerable<TransportLibCm> GetLatestVersions()
         {
-            var dms = _transportRepository.Get()?.LatestVersion()?.OrderBy(x => x.Aspect).ThenBy(x => x.Name, StringComparer.InvariantCultureIgnoreCase).ToList();
+            var dms = _transportRepository.Get()?.LatestVersionsExcludeDeleted()?.OrderBy(x => x.Aspect).ThenBy(x => x.Name, StringComparer.InvariantCultureIgnoreCase).ToList();
 
             if (dms == null)
                 throw new MimirorgNotFoundException("No transports were found.");
@@ -116,14 +117,13 @@ namespace TypeLibrary.Services.Services
             if (!validation.IsValid)
                 throw new MimirorgBadRequestException("Transport is not valid.", validation);
 
-            var transportToUpdate = _transportRepository.Get().LatestVersion().FirstOrDefault(x => x.Id == transportAm.Id);
+            var transportToUpdate = _transportRepository.Get().LatestVersionsExcludeDeleted().FirstOrDefault(x => x.Id == transportAm.Id);
 
             if (transportToUpdate == null)
             {
                 validation = new Validation(new List<string> { nameof(TransportLibAm.Name), nameof(TransportLibAm.Version) },
                     $"Transport with name {transportAm.Name}, aspect {transportAm.Aspect}, Rds Code {transportAm.RdsCode}, id {transportAm.Id} and version {transportAm.Version} does not exist.");
-
-                throw new MimirorgBadRequestException("Transport does not exist. Update is not possible.", validation);
+                throw new MimirorgBadRequestException("Transport does not exist or is flagged as deleted. Update is not possible.", validation);
             }
 
             validation = transportToUpdate.HasIllegalChanges(transportAm);
@@ -136,6 +136,10 @@ namespace TypeLibrary.Services.Services
             if (versionStatus == VersionStatus.NoChange)
                 return GetLatestVersion(transportToUpdate.Id);
 
+            //We need to take into account that there exist a higher version that has state 'Deleted'.
+            //Therefore we need to increment minor/major from the latest version, including those with state 'Deleted'.
+            transportToUpdate.Version = _transportRepository.Get().LatestVersionIncludeDeleted(transportToUpdate.FirstVersionId).Version;
+
             transportAm.Version = versionStatus switch
             {
                 VersionStatus.Minor => transportToUpdate.Version.IncrementMinorVersion(),
@@ -145,9 +149,9 @@ namespace TypeLibrary.Services.Services
 
             var dm = _mapper.Map<TransportLibDm>(transportAm);
 
-            dm.FirstVersionId = transportToUpdate.FirstVersionId;
             dm.State = State.Draft;
-
+            dm.FirstVersionId = transportToUpdate.FirstVersionId;
+            
             await _transportRepository.Create(dm);
             _transportRepository.ClearAllChangeTrackers();
             await _transportRepository.ChangeParentId(transportAm.Id, dm.Id);
@@ -166,7 +170,7 @@ namespace TypeLibrary.Services.Services
         /// <exception cref="MimirorgNotFoundException">Throws if the transport does not exist on latest version</exception>
         public async Task<TransportLibCm> ChangeState(string id, State state)
         {
-            var dm = _transportRepository.Get().LatestVersion().FirstOrDefault(x => x.Id == id);
+            var dm = _transportRepository.Get().LatestVersionsExcludeDeleted().FirstOrDefault(x => x.Id == id);
 
             if (dm == null)
                 throw new MimirorgNotFoundException($"Transport with id {id} not found, or is not latest version.");

--- a/src/server/TypeLibrary.Services/TypeLibrary.Services.csproj
+++ b/src/server/TypeLibrary.Services/TypeLibrary.Services.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="AutoMapper" Version="12.0.0" />
     <PackageReference Include="DelegateDecompiler.EntityFramework" Version="0.30.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>


### PR DESCRIPTION
- Updated all nuget packages (.net 6.0.10).
- Expanded tests.
- Change 'State' now only affect the object, and not every version of the object.
- Updating an obect and calculating new version will now take into account if there exists a higher 'deleted' version of that object before incrementing minor/major version.