### PR TITLE
Feature/form restrictions

### DIFF
--- a/src/client/src/features/entities/common/form-attributes/FormAttributes.tsx
+++ b/src/client/src/features/entities/common/form-attributes/FormAttributes.tsx
@@ -21,6 +21,8 @@ export interface FormAttributesProps {
   remove: (index: number) => void;
   register: (index: number) => UseFormRegisterReturn;
   preprocess?: (attributes?: AttributeLibCm[]) => AttributeLibCm[];
+  canAddAttributes?: boolean;
+  canRemoveAttributes?: boolean;
 }
 
 /**
@@ -31,9 +33,19 @@ export interface FormAttributesProps {
  * @param remove
  * @param register
  * @param preprocess pass a function to alter the attribute data before it is shown to the user
+ * @param canAddAttributes controls if the add action is shown
+ * @param canRemoveAttributes controls if the remove action is shown
  * @constructor
  */
-export const FormAttributes = ({ fields, append, remove, register, preprocess }: FormAttributesProps) => {
+export const FormAttributes = ({
+  fields,
+  append,
+  remove,
+  register,
+  preprocess,
+  canAddAttributes = true,
+  canRemoveAttributes = true,
+}: FormAttributesProps) => {
   const theme = useTheme();
   const { t } = useTranslation("translation", { keyPrefix: "attributes" });
 
@@ -45,15 +57,17 @@ export const FormAttributes = ({ fields, append, remove, register, preprocess }:
     <FormSection
       title={t("title")}
       action={
-        <SelectItemDialog
-          title={t("dialog.title")}
-          description={t("dialog.description")}
-          searchFieldText={t("dialog.search")}
-          addItemsButtonText={t("dialog.add")}
-          openDialogButtonText={t("open")}
-          items={available}
-          onAdd={(ids) => onAddAttributes(ids, attributes, append)}
-        />
+        canAddAttributes && (
+          <SelectItemDialog
+            title={t("dialog.title")}
+            description={t("dialog.description")}
+            searchFieldText={t("dialog.search")}
+            addItemsButtonText={t("dialog.add")}
+            openDialogButtonText={t("open")}
+            items={available}
+            onAdd={(ids) => onAddAttributes(ids, attributes, append)}
+          />
+        )
       }
     >
       <Flexbox flexWrap={"wrap"} gap={theme.tyle.spacing.xl}>
@@ -65,7 +79,7 @@ export const FormAttributes = ({ fields, append, remove, register, preprocess }:
                 key={field.value.id}
                 {...register(index)}
                 {...attribute}
-                actionable
+                actionable={canRemoveAttributes}
                 actionIcon={<Trash />}
                 actionText={t("remove")}
                 onAction={() => remove(index)}

--- a/src/client/src/features/entities/interface/InterfaceForm.tsx
+++ b/src/client/src/features/entities/interface/InterfaceForm.tsx
@@ -44,7 +44,7 @@ export const InterfaceForm = ({ defaultValues = createEmptyFormInterfaceLib(), m
 
   const query = useInterfaceQuery();
   const mapper = (source: InterfaceLibCm) => mapInterfaceLibCmToFormInterfaceLib(source, mode);
-  const [isPrefilled, isLoading] = usePrefilledForm(query, mapper, reset);
+  const [_, isLoading] = usePrefilledForm(query, mapper, reset);
 
   const mutation = useInterfaceMutation(mode);
   useServerValidation(mutation.error, setError);
@@ -62,7 +62,7 @@ export const InterfaceForm = ({ defaultValues = createEmptyFormInterfaceLib(), m
         {isLoading && <Loader />}
         {!isLoading && (
           <>
-            <InterfaceFormBaseFields isPrefilled={isPrefilled} />
+            <InterfaceFormBaseFields mode={mode} />
 
             <Box display={"flex"} flex={3} flexDirection={"column"} gap={theme.tyle.spacing.multiple(6)}>
               <FormAttributes
@@ -71,6 +71,7 @@ export const InterfaceForm = ({ defaultValues = createEmptyFormInterfaceLib(), m
                 append={attributeFields.append}
                 remove={attributeFields.remove}
                 preprocess={prepareAttributes}
+                canRemoveAttributes={mode !== "edit"}
               />
             </Box>
           </>

--- a/src/client/src/features/entities/interface/InterfaceFormBaseFields.tsx
+++ b/src/client/src/features/entities/interface/InterfaceFormBaseFields.tsx
@@ -17,21 +17,22 @@ import { resetSubform } from "features/entities/interface/InterfaceForm.helpers"
 import { InterfaceFormBaseFieldsContainer } from "features/entities/interface/InterfaceFormBaseFields.styled";
 import { InterfaceFormPreview } from "features/entities/interface/InterfaceFormPreview";
 import { FormInterfaceLib } from "features/entities/interface/types/formInterfaceLib";
+import { InterfaceFormMode } from "features/entities/interface/types/interfaceFormMode";
 import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "styled-components";
 
 interface InterfaceFormBaseFieldsProps {
-  isPrefilled?: boolean;
+  mode?: InterfaceFormMode;
 }
 
 /**
  * Component which contains all simple value fields of the interface form.
  *
- * @param isPrefilled
+ * @param mode
  * @constructor
  */
-export const InterfaceFormBaseFields = ({ isPrefilled }: InterfaceFormBaseFieldsProps) => {
+export const InterfaceFormBaseFields = ({ mode }: InterfaceFormBaseFieldsProps) => {
   const theme = useTheme();
   const { t } = useTranslation();
   const { control, register, resetField, setValue, formState } = useFormContext<FormInterfaceLib>();
@@ -49,7 +50,7 @@ export const InterfaceFormBaseFields = ({ isPrefilled }: InterfaceFormBaseFields
 
       <Flexbox flexDirection={"column"} gap={theme.tyle.spacing.l}>
         <FormField label={t("interface.name")} error={errors.name}>
-          <Input placeholder={t("interface.placeholders.name")} {...register("name")} />
+          <Input placeholder={t("interface.placeholders.name")} {...register("name")} disabled={mode === "edit"} />
         </FormField>
 
         <Controller
@@ -78,7 +79,7 @@ export const InterfaceFormBaseFields = ({ isPrefilled }: InterfaceFormBaseFields
           render={({ field: { value, onChange, ref, ...rest } }) => (
             <FormField label={t("interface.aspect")} error={errors.aspect}>
               <ConditionalWrapper
-                condition={isPrefilled}
+                condition={mode === "edit"}
                 wrapper={(c) => (
                   <Popover align={"start"} maxWidth={"225px"} content={t("interface.disabled.aspect")}>
                     <Box borderRadius={theme.tyle.border.radius.medium} tabIndex={0}>
@@ -98,7 +99,7 @@ export const InterfaceFormBaseFields = ({ isPrefilled }: InterfaceFormBaseFields
                     onChange(x?.value);
                   }}
                   value={aspectOptions.find((x) => x.value === value)}
-                  isDisabled={isPrefilled}
+                  isDisabled={mode === "edit"}
                 />
               </ConditionalWrapper>
             </FormField>
@@ -154,6 +155,7 @@ export const InterfaceFormBaseFields = ({ isPrefilled }: InterfaceFormBaseFields
                     onChange(rds.name);
                   }
                 }}
+                isDisabled={mode === "edit"}
               />
             </FormField>
           )}

--- a/src/client/src/features/entities/node/NodeForm.helpers.tsx
+++ b/src/client/src/features/entities/node/NodeForm.helpers.tsx
@@ -28,12 +28,12 @@ export const resetSubform = (resetField: (value: keyof FormNodeLib) => void) => 
   resetField("attributes");
 };
 
-export const getSubformForAspect = (aspect: Aspect) => {
+export const getSubformForAspect = (aspect: Aspect, mode?: NodeFormMode) => {
   switch (aspect) {
     case Aspect.Function:
-      return <NodeFormTerminals />;
+      return <NodeFormTerminals canRemoveTerminals={mode !== "edit"} />;
     case Aspect.Product:
-      return <NodeFormTerminals />;
+      return <NodeFormTerminals canRemoveTerminals={mode !== "edit"} />;
     case Aspect.Location:
       return <NodeFormPredefinedAttributes aspects={[aspect]} />;
     default:

--- a/src/client/src/features/entities/node/NodeForm.tsx
+++ b/src/client/src/features/entities/node/NodeForm.tsx
@@ -45,7 +45,7 @@ export const NodeForm = ({ defaultValues = createEmptyFormNodeLib(), mode }: Nod
 
   const query = useNodeQuery();
   const mapper = (source: NodeLibCm) => mapNodeLibCmToClientModel(source, mode);
-  const [isPrefilled, isLoading] = usePrefilledForm(query, mapper, reset);
+  const [_, isLoading] = usePrefilledForm(query, mapper, reset);
 
   const mutation = useNodeMutation(mode);
   useServerValidation(mutation.error, setError);
@@ -61,16 +61,17 @@ export const NodeForm = ({ defaultValues = createEmptyFormNodeLib(), mode }: Nod
         {isLoading && <Loader />}
         {!isLoading && (
           <>
-            <NodeFormBaseFields isPrefilled={isPrefilled} />
+            <NodeFormBaseFields mode={mode} />
 
             <Box display={"flex"} flex={3} flexDirection={"column"} gap={theme.tyle.spacing.multiple(6)}>
-              {getSubformForAspect(aspect)}
+              {getSubformForAspect(aspect, mode)}
               <FormAttributes
                 register={(index) => register(`attributes.${index}`)}
                 fields={attributeFields.fields}
                 append={attributeFields.append}
                 remove={attributeFields.remove}
                 preprocess={prepareAttributes}
+                canRemoveAttributes={mode !== "edit"}
               />
             </Box>
           </>

--- a/src/client/src/features/entities/node/NodeFormBaseFields.tsx
+++ b/src/client/src/features/entities/node/NodeFormBaseFields.tsx
@@ -17,21 +17,22 @@ import { resetSubform } from "features/entities/node/NodeForm.helpers";
 import { NodeFormBaseFieldsContainer } from "features/entities/node/NodeFormBaseFields.styled";
 import { NodeFormPreview } from "features/entities/node/NodeFormPreview";
 import { FormNodeLib } from "features/entities/node/types/formNodeLib";
+import { NodeFormMode } from "features/entities/node/types/nodeFormMode";
 import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "styled-components/macro";
 
 interface NodeFormBaseFieldsProps {
-  isPrefilled?: boolean;
+  mode?: NodeFormMode;
 }
 
 /**
  * Component which contains all shared fields for variations of the node form.
  *
- * @param isPrefilled
+ * @param mode
  * @constructor
  */
-export const NodeFormBaseFields = ({ isPrefilled }: NodeFormBaseFieldsProps) => {
+export const NodeFormBaseFields = ({ mode }: NodeFormBaseFieldsProps) => {
   const theme = useTheme();
   const { t } = useTranslation();
   const { control, register, resetField, setValue, formState } = useFormContext<FormNodeLib>();
@@ -49,7 +50,7 @@ export const NodeFormBaseFields = ({ isPrefilled }: NodeFormBaseFieldsProps) => 
 
       <Flexbox flexDirection={"column"} gap={theme.tyle.spacing.l}>
         <FormField label={t("node.name")} error={errors.name}>
-          <Input placeholder={t("node.placeholders.name")} {...register("name")} />
+          <Input placeholder={t("node.placeholders.name")} {...register("name")} disabled={mode === "edit"} />
         </FormField>
         <FormField label={t("node.purpose")} error={errors.purposeName}>
           <Controller
@@ -76,7 +77,7 @@ export const NodeFormBaseFields = ({ isPrefilled }: NodeFormBaseFieldsProps) => 
             name={"aspect"}
             render={({ field: { value, onChange, ref, ...rest } }) => (
               <ConditionalWrapper
-                condition={isPrefilled}
+                condition={mode === "edit"}
                 wrapper={(c) => (
                   <Popover align={"start"} maxWidth={"225px"} content={t("node.disabled.aspect")}>
                     <Box borderRadius={theme.tyle.border.radius.medium} tabIndex={0}>
@@ -96,7 +97,7 @@ export const NodeFormBaseFields = ({ isPrefilled }: NodeFormBaseFieldsProps) => 
                     onChange(x?.value);
                   }}
                   value={aspectOptions.find((x) => x.value === value)}
-                  isDisabled={isPrefilled}
+                  isDisabled={mode === "edit"}
                 />
               </ConditionalWrapper>
             )}
@@ -148,6 +149,7 @@ export const NodeFormBaseFields = ({ isPrefilled }: NodeFormBaseFieldsProps) => 
                     onChange(rds.name);
                   }
                 }}
+                isDisabled={mode === "edit"}
               />
             )}
           />

--- a/src/client/src/features/entities/node/terminals/NodeFormTerminals.tsx
+++ b/src/client/src/features/entities/node/terminals/NodeFormTerminals.tsx
@@ -6,7 +6,19 @@ import { createEmptyFormNodeTerminalLib } from "features/entities/node/types/for
 import { useFieldArray, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 
-export const NodeFormTerminals = () => {
+interface NodeFormTerminalsProps {
+  canAddTerminals?: boolean;
+  canRemoveTerminals?: boolean;
+}
+
+/**
+ * Form section for adding terminals to nodes
+ *
+ * @param canAddTerminals controls if the add action is shown
+ * @param canRemoveTerminals controls if the remove action is shown
+ * @constructor
+ */
+export const NodeFormTerminals = ({ canAddTerminals = true, canRemoveTerminals = true }: NodeFormTerminalsProps) => {
   const { t } = useTranslation();
   const { control, setValue, formState } = useFormContext<FormNodeLib>();
   const { errors } = formState;
@@ -17,7 +29,11 @@ export const NodeFormTerminals = () => {
     <FormSection
       title={t("terminals.title")}
       error={errors.nodeTerminals}
-      action={<NodeFormTerminalsAddButton onClick={() => terminalFields.append(createEmptyFormNodeTerminalLib())} />}
+      action={
+        canAddTerminals && (
+          <NodeFormTerminalsAddButton onClick={() => terminalFields.append(createEmptyFormNodeTerminalLib())} />
+        )
+      }
     >
       {terminalFields.fields.map((field, index) => (
         <NodeTerminal
@@ -27,6 +43,7 @@ export const NodeFormTerminals = () => {
           field={field}
           errors={errors}
           setValue={setValue}
+          removable={canRemoveTerminals}
           onRemove={() => terminalFields.remove(index)}
         />
       ))}

--- a/src/client/src/features/entities/node/terminals/NodeTerminal.tsx
+++ b/src/client/src/features/entities/node/terminals/NodeTerminal.tsx
@@ -144,7 +144,7 @@ export const NodeTerminal = ({
                           shouldDirty: true,
                         });
                       checked &&
-                        setValue(`nodeTerminals.${index}.maxQuantity`, MINIMUM_TERMINAL_QUANTITY_VALUE, {
+                        setValue(`nodeTerminals.${index}.maxQuantity`, 1, {
                           shouldDirty: true,
                         });
                       onChange(checked);

--- a/src/client/src/features/entities/node/terminals/NodeTerminal.tsx
+++ b/src/client/src/features/entities/node/terminals/NodeTerminal.tsx
@@ -29,10 +29,32 @@ interface NodeTerminalProps {
   field: FieldArrayWithId<FormNodeLib, "nodeTerminals">;
   errors: FieldErrors<FormNodeLib>;
   setValue: UseFormSetValue<FormNodeLib>;
+  removable: boolean;
   onRemove: () => void;
 }
 
-export const NodeTerminal = ({ index, control, field, errors, setValue, onRemove }: NodeTerminalProps) => {
+/**
+ * Component which represents a single terminal for a given node.
+ * Displays the various input fields that the terminal model supports.
+ *
+ * @param index
+ * @param control
+ * @param field
+ * @param errors
+ * @param setValue
+ * @param removable
+ * @param onRemove
+ * @constructor
+ */
+export const NodeTerminal = ({
+  index,
+  control,
+  field,
+  errors,
+  setValue,
+  removable = true,
+  onRemove,
+}: NodeTerminalProps) => {
   const theme = useTheme();
   const { t } = useTranslation();
 
@@ -51,9 +73,11 @@ export const NodeTerminal = ({ index, control, field, errors, setValue, onRemove
         <Text variant={"label-large"}>
           {t("terminal.title")} #{index + 1}
         </Text>
-        <Button variant={"text"} alignSelf={"end"} icon={<Trash />} iconOnly onClick={() => onRemove()}>
-          {t("terminals.remove")}
-        </Button>
+        {removable && (
+          <Button variant={"text"} alignSelf={"end"} icon={<Trash />} iconOnly onClick={() => onRemove()}>
+            {t("terminals.remove")}
+          </Button>
+        )}
       </Flexbox>
       <NodeTerminalInputContainer>
         <Controller

--- a/src/client/src/features/entities/terminal/TerminalForm.tsx
+++ b/src/client/src/features/entities/terminal/TerminalForm.tsx
@@ -60,7 +60,7 @@ export const TerminalForm = ({ defaultValues = createEmptyFormTerminalLib(), mod
         {isLoading && <Loader />}
         {!isLoading && (
           <>
-            <TerminalFormBaseFields />
+            <TerminalFormBaseFields mode={mode} />
 
             <Box display={"flex"} flex={3} flexDirection={"column"} gap={theme.tyle.spacing.multiple(6)}>
               <FormAttributes
@@ -69,6 +69,7 @@ export const TerminalForm = ({ defaultValues = createEmptyFormTerminalLib(), mod
                 append={attributeFields.append}
                 remove={attributeFields.remove}
                 preprocess={prepareAttributes}
+                canRemoveAttributes={mode !== "edit"}
               />
             </Box>
           </>

--- a/src/client/src/features/entities/terminal/TerminalFormBaseFields.tsx
+++ b/src/client/src/features/entities/terminal/TerminalFormBaseFields.tsx
@@ -8,14 +8,22 @@ import { Flexbox } from "complib/layouts";
 import { TerminalFormBaseFieldsContainer } from "features/entities/terminal/TerminalFormBaseFields.styled";
 import { TerminalFormPreview } from "features/entities/terminal/TerminalFormPreview";
 import { FormTerminalLib } from "features/entities/terminal/types/formTerminalLib";
+import { TerminalFormMode } from "features/entities/terminal/types/terminalFormMode";
 import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "styled-components";
 
+interface TerminalFormBaseFieldsProps {
+  mode?: TerminalFormMode;
+}
+
 /**
  * Component which contains all simple value fields of the terminal form.
+ *
+ * @param mode
+ * @constructor
  */
-export const TerminalFormBaseFields = () => {
+export const TerminalFormBaseFields = ({ mode }: TerminalFormBaseFieldsProps) => {
   const theme = useTheme();
   const { t } = useTranslation();
   const { control, register, formState } = useFormContext<FormTerminalLib>();
@@ -29,7 +37,7 @@ export const TerminalFormBaseFields = () => {
 
       <Flexbox flexDirection={"column"} gap={theme.tyle.spacing.l}>
         <FormField label={t("terminal.name")} error={errors.name}>
-          <Input placeholder={t("terminal.placeholders.name")} {...register("name")} />
+          <Input placeholder={t("terminal.placeholders.name")} {...register("name")} disabled={mode === "edit"} />
         </FormField>
 
         <FormField label={t("terminal.color")} error={errors.color}>

--- a/src/client/src/features/entities/transport/TransportForm.tsx
+++ b/src/client/src/features/entities/transport/TransportForm.tsx
@@ -44,7 +44,7 @@ export const TransportForm = ({ defaultValues = createEmptyFormTransportLib(), m
 
   const query = useTransportQuery();
   const mapper = (source: TransportLibCm) => mapTransportLibCmToFormTransportLib(source, mode);
-  const [isPrefilled, isLoading] = usePrefilledForm(query, mapper, reset);
+  const [_, isLoading] = usePrefilledForm(query, mapper, reset);
 
   const mutation = useTransportMutation(mode);
   useServerValidation(mutation.error, setError);
@@ -62,7 +62,7 @@ export const TransportForm = ({ defaultValues = createEmptyFormTransportLib(), m
         {isLoading && <Loader />}
         {!isLoading && (
           <>
-            <TransportFormBaseFields isPrefilled={isPrefilled} />
+            <TransportFormBaseFields mode={mode} />
 
             <Box display={"flex"} flex={3} flexDirection={"column"} gap={theme.tyle.spacing.multiple(6)}>
               <FormAttributes
@@ -71,6 +71,7 @@ export const TransportForm = ({ defaultValues = createEmptyFormTransportLib(), m
                 append={attributeFields.append}
                 remove={attributeFields.remove}
                 preprocess={prepareAttributes}
+                canRemoveAttributes={mode !== "edit"}
               />
             </Box>
           </>

--- a/src/client/src/features/entities/transport/TransportFormBaseFields.tsx
+++ b/src/client/src/features/entities/transport/TransportFormBaseFields.tsx
@@ -17,21 +17,22 @@ import { resetSubform } from "features/entities/transport/TransportForm.helpers"
 import { TransportFormBaseFieldsContainer } from "features/entities/transport/TransportFormBaseFields.styled";
 import { TransportFormPreview } from "features/entities/transport/TransportFormPreview";
 import { FormTransportLib } from "features/entities/transport/types/formTransportLib";
+import { TransportFormMode } from "features/entities/transport/types/transportFormMode";
 import { Controller, useFormContext } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "styled-components";
 
 interface TransportFormBaseFieldsProps {
-  isPrefilled?: boolean;
+  mode?: TransportFormMode;
 }
 
 /**
  * Component which contains all simple value fields of the transport form.
  *
- * @param isPrefilled
+ * @param mode
  * @constructor
  */
-export const TransportFormBaseFields = ({ isPrefilled }: TransportFormBaseFieldsProps) => {
+export const TransportFormBaseFields = ({ mode }: TransportFormBaseFieldsProps) => {
   const theme = useTheme();
   const { t } = useTranslation();
   const { control, register, resetField, setValue, formState } = useFormContext<FormTransportLib>();
@@ -49,7 +50,7 @@ export const TransportFormBaseFields = ({ isPrefilled }: TransportFormBaseFields
 
       <Flexbox flexDirection={"column"} gap={theme.tyle.spacing.l}>
         <FormField label={t("transport.name")} error={errors.name}>
-          <Input placeholder={t("transport.placeholders.name")} {...register("name")} />
+          <Input placeholder={t("transport.placeholders.name")} {...register("name")} disabled={mode === "edit"} />
         </FormField>
 
         <Controller
@@ -78,7 +79,7 @@ export const TransportFormBaseFields = ({ isPrefilled }: TransportFormBaseFields
           render={({ field: { value, onChange, ref, ...rest } }) => (
             <FormField label={t("transport.aspect")} error={errors.aspect}>
               <ConditionalWrapper
-                condition={isPrefilled}
+                condition={mode === "edit"}
                 wrapper={(c) => (
                   <Popover align={"start"} maxWidth={"225px"} content={t("transport.disabled.aspect")}>
                     <Box borderRadius={theme.tyle.border.radius.medium} tabIndex={0}>
@@ -98,7 +99,7 @@ export const TransportFormBaseFields = ({ isPrefilled }: TransportFormBaseFields
                     onChange(x?.value);
                   }}
                   value={aspectOptions.find((x) => x.value === value)}
-                  isDisabled={isPrefilled}
+                  isDisabled={mode === "edit"}
                 />
               </ConditionalWrapper>
             </FormField>
@@ -154,6 +155,7 @@ export const TransportFormBaseFields = ({ isPrefilled }: TransportFormBaseFields
                     onChange(rds.name);
                   }
                 }}
+                isDisabled={mode === "edit"}
               />
             </FormField>
           )}


### PR DESCRIPTION
# Form restrictions

## Goals 🎯
- Disable/restrict fields/actions during edit
- Addresses restrictions mentioned in #219 

## Noteworthy changes 📜
- [feat(client): adjusts interface form's disabled fields during edit](https://github.com/mimir-org/typelibrary/commit/1ddc2efef795368eb4dbf1da6dd1c843987d2432)
- [feat(client): adjusts node form's disabled fields during edit](https://github.com/mimir-org/typelibrary/commit/705860fd8ef2bb887956d4c9df40cb8f717378b1)
- [feat(client): adjusts terminal form's disabled fields during edit](https://github.com/mimir-org/typelibrary/commit/b62cc5fce9df7512461ec77c299742395c7ad650)
- [feat(client): adjusts transport form's disabled fields during edit](https://github.com/mimir-org/typelibrary/commit/50579f0963e9d147e31ce71e98428019942daa2f)
- [feat(client): extends FormAttributes with flags for controlling add/remove](https://github.com/mimir-org/typelibrary/commit/59c0b7ad71f2802bc0e49c2ba65ee012e50dc415)