### PR TITLE
Changed button filter logic

### DIFF
--- a/src/client/src/features/explore/search/hooks/useButtonFilter.ts
+++ b/src/client/src/features/explore/search/hooks/useButtonFilter.ts
@@ -33,8 +33,8 @@ export const useButtonStateFilter = (item: StateItem | null, user: UserItem | nu
   useEffect(() => {
     const currentButtonState: ButtonState = {
       clone: allowClone(item ?? null, user),
-      edit: allowEditDelete(item ?? null, user),
-      delete: allowEditDelete(item ?? null, user),
+      edit: allowEdit(item ?? null, user),
+      delete: allowDelete(item ?? null, user),
       approve: allowApprove(item ?? null, user),
       deleted: item?.state === State.Deleted,
       approved: item?.state === State.Approved,
@@ -55,7 +55,7 @@ const allowClone = (item: StateItem | null, user: UserItem | null): boolean => {
   return anyWrite && item.state !== State.Delete && item.state !== State.Deleted;
 };
 
-const allowEditDelete = (item: StateItem | null, user: UserItem | null): boolean => {
+const allowEdit = (item: StateItem | null, user: UserItem | null): boolean => {
   if (item == null || user == null) return false;
 
   let permissionForCompany: MimirorgPermission;
@@ -67,7 +67,22 @@ const allowEditDelete = (item: StateItem | null, user: UserItem | null): boolean
   if (permissionForCompany == null) return false;
 
   const hasMinimumWrite = (permissionForCompany & MimirorgPermission.Write) === MimirorgPermission.Write;
-  return hasMinimumWrite && item.state !== State.Delete && item.state !== State.Deleted;
+  return hasMinimumWrite && item.state !== State.Approve && item.state !== State.Delete && item.state !== State.Deleted;
+};
+
+const allowDelete = (item: StateItem | null, user: UserItem | null): boolean => {
+  if (item == null || user == null) return false;
+
+  let permissionForCompany: MimirorgPermission;
+  if (isAspectObjectItem(item)) {
+    permissionForCompany = user.permissions[item.companyId]?.value;
+  } else {
+    permissionForCompany = user.permissions[0].value;
+  }
+  if (permissionForCompany == null) return false;
+
+  const hasMinimumWrite = (permissionForCompany & MimirorgPermission.Write) === MimirorgPermission.Write;
+  return hasMinimumWrite && item.state === State.Draft;
 };
 
 const allowApprove = (item: StateItem | null, user: UserItem | null): boolean => {
@@ -82,5 +97,5 @@ const allowApprove = (item: StateItem | null, user: UserItem | null): boolean =>
   if (permissionForCompany == null) return false;
 
   const hasMinimumWrite = (permissionForCompany & MimirorgPermission.Write) === MimirorgPermission.Write;
-  return hasMinimumWrite && item.state !== State.Delete && item.state !== State.Deleted && item.state !== State.Approve;
+  return hasMinimumWrite && item.state === State.Draft;
 };


### PR DESCRIPTION
Split edit and delete logic. Edit is allowed for objects that are not deleted and not in "transit" states (waiting for deletion or approval). Delete is only allowed for draft objects.

The flow of object states might be a little hard to work with, but it seems to me to be the most in line with earlier discussions.