### PR TITLE
Hide terminal limit controls for aspect != product

### DIFF
--- a/src/client/src/features/entities/aspectobject/terminals/AspectObjectTerminal.tsx
+++ b/src/client/src/features/entities/aspectobject/terminals/AspectObjectTerminal.tsx
@@ -124,58 +124,60 @@ export const AspectObjectTerminal = ({
               </FormField>
             )}
           />
-          <AspectObjectTerminalInputContainer>
-            <Controller
-              control={control}
-              name={`aspectObjectTerminals.${index}.hasMaxQuantity`}
-              render={({ field: { onChange, value, ...rest } }) => (
-                <FormField
-                  indent={false}
-                  label={t("aspectObject.terminals.limit")}
-                  error={errors.aspectObjectTerminals?.[index]?.hasMaxQuantity}
-                >
-                  <Box display={"flex"} justifyContent={"center"} alignItems={"center"} height={"40px"}>
-                    <Checkbox
+          {terminalCanHaveLimit && (
+            <AspectObjectTerminalInputContainer>
+              <Controller
+                control={control}
+                name={`aspectObjectTerminals.${index}.hasMaxQuantity`}
+                render={({ field: { onChange, value, ...rest } }) => (
+                  <FormField
+                    indent={false}
+                    label={t("aspectObject.terminals.limit")}
+                    error={errors.aspectObjectTerminals?.[index]?.hasMaxQuantity}
+                  >
+                    <Box display={"flex"} justifyContent={"center"} alignItems={"center"} height={"40px"}>
+                      <Checkbox
+                        {...rest}
+                        onCheckedChange={(checked) => {
+                          !checked &&
+                            setValue(`aspectObjectTerminals.${index}.maxQuantity`, MAXIMUM_TERMINAL_QUANTITY_VALUE, {
+                              shouldDirty: true,
+                            });
+                          checked &&
+                            setValue(`aspectObjectTerminals.${index}.maxQuantity`, 1, {
+                              shouldDirty: true,
+                            });
+                          onChange(checked);
+                        }}
+                        checked={value}
+                        disabled={!terminalCanHaveLimit}
+                      />
+                    </Box>
+                  </FormField>
+                )}
+              />
+              <Controller
+                control={control}
+                name={`aspectObjectTerminals.${index}.maxQuantity`}
+                render={({ field: { value, ...rest } }) => (
+                  <FormField
+                    indent={false}
+                    label={t("aspectObject.terminals.amount")}
+                    error={errors.aspectObjectTerminals?.[index]?.maxQuantity}
+                  >
+                    <Counter
                       {...rest}
-                      onCheckedChange={(checked) => {
-                        !checked &&
-                          setValue(`aspectObjectTerminals.${index}.maxQuantity`, MAXIMUM_TERMINAL_QUANTITY_VALUE, {
-                            shouldDirty: true,
-                          });
-                        checked &&
-                          setValue(`aspectObjectTerminals.${index}.maxQuantity`, 1, {
-                            shouldDirty: true,
-                          });
-                        onChange(checked);
-                      }}
-                      checked={value}
-                      disabled={!terminalCanHaveLimit}
+                      id={field.id}
+                      min={MINIMUM_TERMINAL_QUANTITY_VALUE}
+                      max={MAXIMUM_TERMINAL_QUANTITY_VALUE}
+                      value={!terminalHasMaxQuantity ? 0 : value}
+                      disabled={!terminalHasMaxQuantity}
                     />
-                  </Box>
-                </FormField>
-              )}
-            />
-            <Controller
-              control={control}
-              name={`aspectObjectTerminals.${index}.maxQuantity`}
-              render={({ field: { value, ...rest } }) => (
-                <FormField
-                  indent={false}
-                  label={t("aspectObject.terminals.amount")}
-                  error={errors.aspectObjectTerminals?.[index]?.maxQuantity}
-                >
-                  <Counter
-                    {...rest}
-                    id={field.id}
-                    min={MINIMUM_TERMINAL_QUANTITY_VALUE}
-                    max={MAXIMUM_TERMINAL_QUANTITY_VALUE}
-                    value={!terminalHasMaxQuantity ? 0 : value}
-                    disabled={!terminalHasMaxQuantity}
-                  />
-                </FormField>
-              )}
-            />
-          </AspectObjectTerminalInputContainer>
+                  </FormField>
+                )}
+              />
+            </AspectObjectTerminalInputContainer>
+          )}
         </AspectObjectTerminalInputContainer>
         {sourceTerminal && sourceTerminal.attributes.length >= 4 ? (
           <Accordion>


### PR DESCRIPTION
Since there can only be set a limit for terminals in the product aspect, these controls should be hidden when they are not usable.