### PR TITLE
[BOUBEST-178] Feil musepeker på noen objekt

### DIFF
--- a/src/client/src/features/common/terminal/TerminalButton.styled.ts
+++ b/src/client/src/features/common/terminal/TerminalButton.styled.ts
@@ -21,7 +21,7 @@ export const TerminalButtonContainer = styled.button<TerminalButtonProps>`
   letter-spacing: ${(props) => props.theme.tyle.typography.sys.roles.label.large.letterSpacing};
 
   :hover {
-    cursor: pointer;
+    cursor: default;
   }
 
   :disabled {

--- a/src/client/src/features/icons/UnitIcon.tsx
+++ b/src/client/src/features/icons/UnitIcon.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 const UnitIcon = () => (
   <svg
     width="100%"


### PR DESCRIPTION
Endret 'TerminalButton.styled' cursor fra 'pointer' til 'default'. 

**_Dette er en global endring så sjekk at denne endringen ikke påvirker andre steder i Tyle negativt_**. Jeg har sjekket selv, og kan ikke se at denne endringen påvirker noe annet 'negativt'.

Hvorfor musepeker var satt til 'pointer' kan kanskje henge igjen fra tidligere? De objektene som nå bruker TerminalButtonContainer ser ikke ut til å lenke (være klikkbar) til noe. 