### PR TITLE
[BOUBEST-182] Darkmode - Forbedringsforslag

### DIFF
--- a/src/client/src/common/utils/getColorFromAspect.ts
+++ b/src/client/src/common/utils/getColorFromAspect.ts
@@ -3,8 +3,9 @@ import { Aspect } from "@mimirorg/typelibrary-types";
 export const getColorFromAspect = (aspect: Aspect) => {
   switch (aspect) {
     case Aspect.NotSet:
+      return "hsl(318, 29%, 91%)";
     case Aspect.None:
-      return "";
+      return "hsl(318, 29%, 91%)";
     case Aspect.Function:
       return "hsl(57,99%,63%)";
     case Aspect.Product:

--- a/src/client/src/complib/core/variables/color/themes/darkTheme.ts
+++ b/src/client/src/complib/core/variables/color/themes/darkTheme.ts
@@ -3,7 +3,7 @@ import { ColorTheme } from "complib/core/variables/color/types/colorTheme";
 
 export const darkTheme: ColorTheme = {
   primary: {
-    base: colorReference.neutral[50],
+    base: colorReference.neutral[60],
     on: colorReference.primary[0]
   },
   secondary: {

--- a/src/client/src/features/entities/terminal/types/formTerminalLib.ts
+++ b/src/client/src/features/entities/terminal/types/formTerminalLib.ts
@@ -26,7 +26,7 @@ export const mapTerminalLibCmToFormTerminalLib = (terminalLibCm: TerminalLibCm):
 export const createEmptyFormTerminalLib = (): FormTerminalLib => ({
   ...emptyTerminalLibAm,
   attributes: [],
-  color: "#f7f6ff",
+  color: "#d0d0dd",
 });
 
 const emptyTerminalLibAm: TerminalLibAm = {

--- a/src/client/src/features/ui/header/contact/ContactCard.tsx
+++ b/src/client/src/features/ui/header/contact/ContactCard.tsx
@@ -29,7 +29,7 @@ export const ContactCard = ({ name, email }: ContactCardProps) => {
       <User size={34} color={theme.tyle.color.sys.primary.base} />
       <Box maxWidth={"200px"}>
         <Text variant={"title-medium"}>{name}</Text>
-        <Text as={"a"} href={`mailto:${email}`} variant={"title-small"}>
+        <Text color={theme.tyle.color.sys.primary.base} as={"a"} href={`mailto:${email}`} variant={"title-small"}>
           {email}
         </Text>
       </Box>


### PR DESCRIPTION
I filtersøket, så er sjekkboksen svak kontrask mot den grønfargen.
**_Justert kontrasten for at det skal bli bedre i darkmode._**

Nokre aspekobjekt har svart tekst på grå bakgrunn (vanskeleg å lese). 
**_Endret aspect 'none' og 'not set' til en annen bakgrunnsfarge som fungerer både med/uten darkmode._**

I settingsmenyen, "Contact", så er det blå epostadresse på svart bakgrunn. 
**_Dette er rettet slik at det fungerer med/uten darkmode._**

I settingsmenyen, så syns eg at det er grått på svart kunne hatt betre kontrast. Det er mykje betre lesbart i lys modus. 
**_Vi lar dette være slik det er nå._**