### PR TITLE
Fixed a bug where you couldn't edit an attribute

### DIFF
--- a/src/client/src/features/entities/RDS/RdsFormBaseFields.tsx
+++ b/src/client/src/features/entities/RDS/RdsFormBaseFields.tsx
@@ -19,19 +19,19 @@ export const RdsFormBaseFields = ({ limited }: RdsFormBaseFieldsProps) => {
 
   return (
     <FormBaseFieldsContainer>
-    <Flexbox flexDirection={"column"} gap={theme.tyle.spacing.l}>
-      <FormField label={t("rds.name")} error={errors.name}>
-        <Input placeholder={t("rds.name")} {...register("name")} required disabled={limited} />
-      </FormField>
+      <Flexbox flexDirection={"column"} gap={theme.tyle.spacing.l}>
+        <FormField label={t("rds.name")} error={errors.name}>
+          <Input placeholder={t("rds.name")} {...register("name")} required disabled={limited} />
+        </FormField>
 
-      <FormField label={t("rds.rdsCode")} error={errors.rdsCode}>
-        <Input placeholder={t("rds.placeholders.rdsCode")} {...register("rdsCode")} required disabled={limited} />
-      </FormField>
+        <FormField label={t("rds.rdsCode")} error={errors.rdsCode}>
+          <Input placeholder={t("rds.placeholders.rdsCode")} {...register("rdsCode")} required disabled={limited} />
+        </FormField>
 
-      <FormField label={t("rds.description")} error={errors.description}>
-        <Textarea placeholder={t("rds.placeholders.description")} {...register("description")} />
-      </FormField>
-    </Flexbox>
+        <FormField label={t("rds.description")} error={errors.description}>
+          <Textarea placeholder={t("rds.placeholders.description")} {...register("description")} />
+        </FormField>
+      </Flexbox>
     </FormBaseFieldsContainer>
   );
 };

--- a/src/client/src/features/entities/attributes/types/formAttributeLib.ts
+++ b/src/client/src/features/entities/attributes/types/formAttributeLib.ts
@@ -1,5 +1,5 @@
 import { AttributeLibAm, AttributeLibCm, UnitLibCm } from "@mimirorg/typelibrary-types";
-import { FormUnitHelper, createEmptyFormUnitHelper } from "features/entities/units/types/FormUnitHelper";
+import { FormUnitHelper } from "features/entities/units/types/FormUnitHelper";
 
 export interface FormAttributeLib extends Omit<AttributeLibAm, "attributeUnits"> {
   units: FormUnitHelper[];
@@ -16,16 +16,19 @@ export const fromFormAttributeLibToApiModel = (formAttribute: FormAttributeLib):
   })),
 });
 
-export const toFormAttributeLib = (attribute: AttributeLibCm): FormAttributeLib => ({
-  name: attribute.name,
-  typeReference: attribute.typeReference,
-  description: attribute.description,
-  units: attribute.attributeUnits.map((x) => toFormUnitHelper(x.unit)),
-  defaultUnit: toFormUnitHelper(attribute.attributeUnits.find((x) => x.isDefault === true)?.unit),
-});
+export const toFormAttributeLib = (attribute: AttributeLibCm): FormAttributeLib => {
+  const defaultUnit = attribute.attributeUnits.find((x) => x.isDefault === true)?.unit;
 
-export const toFormUnitHelper = (unit: UnitLibCm | undefined): FormUnitHelper => {
-  if (!unit) return createEmptyFormUnitHelper();
+  return {
+    name: attribute.name,
+    typeReference: attribute.typeReference,
+    description: attribute.description,
+    units: attribute.attributeUnits.map((x) => toFormUnitHelper(x.unit)),
+    defaultUnit: defaultUnit ? toFormUnitHelper(defaultUnit) : null,
+  }
+};
+
+export const toFormUnitHelper = (unit: UnitLibCm): FormUnitHelper => {
   return {
     name: unit.name,
     description: unit.description,

--- a/src/client/src/features/entities/attributes/types/formAttributeLib.ts
+++ b/src/client/src/features/entities/attributes/types/formAttributeLib.ts
@@ -25,7 +25,7 @@ export const toFormAttributeLib = (attribute: AttributeLibCm): FormAttributeLib 
     description: attribute.description,
     units: attribute.attributeUnits.map((x) => toFormUnitHelper(x.unit)),
     defaultUnit: defaultUnit ? toFormUnitHelper(defaultUnit) : null,
-  }
+  };
 };
 
 export const toFormUnitHelper = (unit: UnitLibCm): FormUnitHelper => {

--- a/src/client/src/features/entities/quantityDatum/QuantityDatumFormBaseFields.tsx
+++ b/src/client/src/features/entities/quantityDatum/QuantityDatumFormBaseFields.tsx
@@ -23,36 +23,36 @@ export const QuantityDatumFormBaseFields = ({ limited }: QuantityDatumFormBaseFi
 
   return (
     <>
-    <FormBaseFieldsContainer>
-      <FormField label={t("quantityDatum.name")} error={errors.name}>
-        <Input placeholder={t("quantityDatum.placeholders.name")} {...register("name")} required disabled={limited} />
-      </FormField>
+      <FormBaseFieldsContainer>
+        <FormField label={t("quantityDatum.name")} error={errors.name}>
+          <Input placeholder={t("quantityDatum.placeholders.name")} {...register("name")} required disabled={limited} />
+        </FormField>
 
-      <FormField label={t("quantityDatum.quantityType")} error={errors.quantityDatumType}>
-        <Controller
-          control={control}
-          name={"quantityDatumType"}
-          render={({ field: { ref, onChange } }) => (
-            <Select
-              required={true}
-              selectRef={ref}
-              placeholder={t("common.templates.select", { object: t("quantityDatum.title").toLowerCase() })}
-              options={quantityDatumTypeArray}
-              getOptionValue={(x) => x.value}
-              getOptionLabel={(x) => x.name}
-              value={quantityDatumTypeArray.find((x) => x.value === getValues("quantityDatumType").toString())}
-              onChange={(x) => {
-                onChange(x?.value);
-              }}
-              isDisabled={limited}
-            />
-          )}
-        />
-      </FormField>
+        <FormField label={t("quantityDatum.quantityType")} error={errors.quantityDatumType}>
+          <Controller
+            control={control}
+            name={"quantityDatumType"}
+            render={({ field: { ref, onChange } }) => (
+              <Select
+                required={true}
+                selectRef={ref}
+                placeholder={t("common.templates.select", { object: t("quantityDatum.title").toLowerCase() })}
+                options={quantityDatumTypeArray}
+                getOptionValue={(x) => x.value}
+                getOptionLabel={(x) => x.name}
+                value={quantityDatumTypeArray.find((x) => x.value === getValues("quantityDatumType").toString())}
+                onChange={(x) => {
+                  onChange(x?.value);
+                }}
+                isDisabled={limited}
+              />
+            )}
+          />
+        </FormField>
 
-      <FormField label={t("quantityDatum.description")} error={errors.description}>
-        <Textarea placeholder={t("quantityDatum.placeholders.description")} {...register("description")} />
-      </FormField>
+        <FormField label={t("quantityDatum.description")} error={errors.description}>
+          <Textarea placeholder={t("quantityDatum.placeholders.description")} {...register("description")} />
+        </FormField>
       </FormBaseFieldsContainer>
     </>
   );

--- a/src/client/src/features/entities/terminal/TerminalFormBaseFields.tsx
+++ b/src/client/src/features/entities/terminal/TerminalFormBaseFields.tsx
@@ -30,7 +30,7 @@ export const TerminalFormBaseFields = ({ limited }: TerminalFormBaseFieldsProps)
     <FormBaseFieldsContainer>
       <Text variant={"display-small"}>{t("terminal.title")}</Text>
       <TerminalFormPreview control={control} />
-        <Flexbox flexDirection={"column"} gap={theme.tyle.spacing.l}>
+      <Flexbox flexDirection={"column"} gap={theme.tyle.spacing.l}>
         <FormField label={t("terminal.name")} error={errors.name}>
           <Input placeholder={t("terminal.placeholders.name")} {...register("name")} disabled={limited} />
         </FormField>

--- a/src/client/src/features/entities/units/UnitFormBaseFields.tsx
+++ b/src/client/src/features/entities/units/UnitFormBaseFields.tsx
@@ -22,29 +22,29 @@ export default function UnitFormBaseFields({ limited }: UnitFormBaseFieldsProps)
 
   return (
     <FormBaseFieldsContainer>
-    <Flexbox flexDirection={"column"} gap={theme.tyle.spacing.l}>
-      <Text variant={"display-small"}>{t("unit.title")}</Text>
-      <FormField label={t("unit.name")} error={errors.name}>
-        <Input placeholder={t("unit.placeholders.name")} {...register("name")} required disabled={limited} />
-      </FormField>
+      <Flexbox flexDirection={"column"} gap={theme.tyle.spacing.l}>
+        <Text variant={"display-small"}>{t("unit.title")}</Text>
+        <FormField label={t("unit.name")} error={errors.name}>
+          <Input placeholder={t("unit.placeholders.name")} {...register("name")} required disabled={limited} />
+        </FormField>
 
-      <FormField label={t("unit.symbol")} error={errors.symbol}>
-        <Input placeholder={t("unit.placeholders.symbol")} {...register("symbol")} disabled={limited} />
-      </FormField>
+        <FormField label={t("unit.symbol")} error={errors.symbol}>
+          <Input placeholder={t("unit.placeholders.symbol")} {...register("symbol")} disabled={limited} />
+        </FormField>
 
-      <FormField label={t("unit.description")} error={errors.description}>
-        <Textarea placeholder={t("unit.placeholders.description")} {...register("description")} />
-      </FormField>
+        <FormField label={t("unit.description")} error={errors.description}>
+          <Textarea placeholder={t("unit.placeholders.description")} {...register("description")} />
+        </FormField>
 
-      <Flexbox justifyContent={"center"} gap={theme.tyle.spacing.xl}>
-        <PlainLink tabIndex={-1} to={"/"}>
-          <Button tabIndex={0} as={"span"} variant={"outlined"} dangerousAction>
-            {t("common.cancel")}
-          </Button>
-        </PlainLink>
-        <Button type={"submit"}>{t("common.submit")}</Button>
+        <Flexbox justifyContent={"center"} gap={theme.tyle.spacing.xl}>
+          <PlainLink tabIndex={-1} to={"/"}>
+            <Button tabIndex={0} as={"span"} variant={"outlined"} dangerousAction>
+              {t("common.cancel")}
+            </Button>
+          </PlainLink>
+          <Button type={"submit"}>{t("common.submit")}</Button>
+        </Flexbox>
       </Flexbox>
-    </Flexbox>
     </FormBaseFieldsContainer>
   );
 }

--- a/src/client/src/features/entities/units/types/FormUnitHelper.ts
+++ b/src/client/src/features/entities/units/types/FormUnitHelper.ts
@@ -4,10 +4,3 @@ export interface FormUnitHelper {
   symbol: string;
   unitId: string;
 }
-
-export const createEmptyFormUnitHelper = (): FormUnitHelper => ({
-  name: "",
-  description: "",
-  symbol: "",
-  unitId: "",
-});


### PR DESCRIPTION
If you created an attribute without units you couldn't edit it This was because the default unit was undefined in this case, which caused validation to fail
Changed it so that the default unit if not set would be mapped to null