### PR TITLE
Fix/attributes-bug

### DIFF
--- a/src/server/Tests/Mimirorg.Setup/Fixtures/MimirorgCommonFixture.cs
+++ b/src/server/Tests/Mimirorg.Setup/Fixtures/MimirorgCommonFixture.cs
@@ -118,27 +118,6 @@ public class MimirorgCommonFixture : IDisposable
         return (aspectObjectLibAm, aspectObjectLibDm);
     }
 
-    public (TerminalLibAm am, TerminalLibDm dm) CreateTerminalTestData()
-    {
-        var terminalLibAm = new TerminalLibAm
-        {
-            Name = "AA",
-            TypeReference = "https://www.tyle.com/",
-            Color = "#123",
-            Attributes = new List<string>()
-        };
-
-        var terminalLibDm = new TerminalLibDm
-        {
-            Name = "AA",
-            Color = "#123",
-            Attributes = new List<AttributeLibDm>(),
-            TypeReference = "https://www.tyle.com/"
-        };
-
-        return (terminalLibAm, terminalLibDm);
-    }
-
     public void Dispose()
     {
 

--- a/src/server/TypeLibrary.Core/Profiles/AspectObjectProfile.cs
+++ b/src/server/TypeLibrary.Core/Profiles/AspectObjectProfile.cs
@@ -36,7 +36,6 @@ public class AspectObjectProfile : Profile
             .ForMember(dest => dest.Symbol, opt => opt.MapFrom(src => src.Symbol))
             .ForMember(dest => dest.Description, opt => opt.MapFrom(src => src.Description))
             .ForMember(dest => dest.AspectObjectTerminals, opt => opt.MapFrom(src => CreateTerminals(src.AspectObjectTerminals)))
-            .ForMember(dest => dest.Attributes, opt => opt.Ignore())
             .ForMember(dest => dest.AspectObjectAttributes, opt => opt.Ignore())
             .ForMember(dest => dest.SelectedAttributePredefined, opt => opt.MapFrom(src => src.SelectedAttributePredefined));
 
@@ -60,7 +59,7 @@ public class AspectObjectProfile : Profile
             .ForMember(dest => dest.Symbol, opt => opt.MapFrom(src => src.Symbol))
             .ForMember(dest => dest.Description, opt => opt.MapFrom(src => src.Description))
             .ForMember(dest => dest.AspectObjectTerminals, opt => opt.MapFrom(src => src.AspectObjectTerminals))
-            .ForMember(dest => dest.Attributes, opt => opt.MapFrom(src => src.Attributes))
+            .ForMember(dest => dest.Attributes, opt => opt.MapFrom(src => src.AspectObjectAttributes.Select(x => x.Attribute)))
             .ForMember(dest => dest.SelectedAttributePredefined, opt => opt.MapFrom(src => src.SelectedAttributePredefined));
 
         CreateMap<AspectObjectLibCm, ApprovalCm>()

--- a/src/server/TypeLibrary.Core/Profiles/TerminalProfile.cs
+++ b/src/server/TypeLibrary.Core/Profiles/TerminalProfile.cs
@@ -4,6 +4,7 @@ using Mimirorg.Common.Extensions;
 using Mimirorg.TypeLibrary.Models.Application;
 using Mimirorg.TypeLibrary.Models.Client;
 using System;
+using System.Linq;
 using TypeLibrary.Core.Profiles.Resolvers;
 using TypeLibrary.Data.Constants;
 using TypeLibrary.Data.Contracts;
@@ -26,7 +27,6 @@ public class TerminalProfile : Profile
             .ForMember(dest => dest.Color, opt => opt.MapFrom(src => src.Color))
             .ForMember(dest => dest.Description, opt => opt.MapFrom(src => src.Description))
             .ForMember(dest => dest.TerminalAspectObjects, opt => opt.Ignore())
-            .ForMember(dest => dest.Attributes, opt => opt.Ignore())
             .ForMember(dest => dest.TerminalAttributes, opt => opt.Ignore());
 
         CreateMap<TerminalLibDm, TerminalLibCm>()
@@ -39,7 +39,7 @@ public class TerminalProfile : Profile
             .ForMember(dest => dest.State, opt => opt.MapFrom(src => src.State))
             .ForMember(dest => dest.Color, opt => opt.MapFrom(src => src.Color))
             .ForMember(dest => dest.Description, opt => opt.MapFrom(src => src.Description))
-            .ForMember(dest => dest.Attributes, opt => opt.MapFrom(src => src.Attributes));
+            .ForMember(dest => dest.Attributes, opt => opt.MapFrom(src => src.TerminalAttributes.Select(x => x.Attribute)));
 
         CreateMap<TerminalLibCm, ApprovalCm>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id))

--- a/src/server/TypeLibrary.Data/Models/AspectObjectLibDm.cs
+++ b/src/server/TypeLibrary.Data/Models/AspectObjectLibDm.cs
@@ -32,7 +32,6 @@ public class AspectObjectLibDm : IVersionable<AspectObjectLibAm>, IVersionObject
     public string Symbol { get; set; }
     public string Description { get; set; }
     public virtual ICollection<AspectObjectTerminalLibDm> AspectObjectTerminals { get; set; }
-    public ICollection<AttributeLibDm> Attributes { get; set; }
     public virtual ICollection<AspectObjectAttributeLibDm> AspectObjectAttributes { get; set; }
     public virtual List<SelectedAttributePredefinedLibDm> SelectedAttributePredefined { get; set; }
 
@@ -53,13 +52,13 @@ public class AspectObjectLibDm : IVersionable<AspectObjectLibAm>, IVersionObject
 
         //Attributes
         var attributeAmIds = new List<string>();
-        var attributeDms = new List<AttributeLibDm>();
+        var aspectObjectAttributeDms = new List<AspectObjectAttributeLibDm>();
 
         attributeAmIds.AddRange(other.Attributes ?? new List<string>());
-        attributeDms.AddRange(Attributes ?? new List<AttributeLibDm>());
+        aspectObjectAttributeDms.AddRange(AspectObjectAttributes ?? new List<AspectObjectAttributeLibDm>());
 
-        if (attributeDms.Select(y => y.Id).Any(id => attributeAmIds.All(x => x != id)))
-            validation.AddNotAllowToChange(nameof(Attributes), "It is not allowed to remove or change attributes");
+        if (aspectObjectAttributeDms.Select(y => y.AttributeId).Any(id => attributeAmIds.All(x => x != id)))
+            validation.AddNotAllowToChange(nameof(AspectObjectAttributes), "It is not allowed to remove or change attributes");
 
         //Terminals
         AspectObjectTerminals ??= new List<AspectObjectTerminalLibDm>();
@@ -119,12 +118,12 @@ public class AspectObjectLibDm : IVersionable<AspectObjectLibAm>, IVersionObject
 
         //Attributes
         var attributeAmIds = new List<string>();
-        var attributeDms = new List<AttributeLibDm>();
+        var aspectObjectAttributeDms = new List<AspectObjectAttributeLibDm>();
 
         attributeAmIds.AddRange(other.Attributes ?? new List<string>());
-        attributeDms.AddRange(Attributes ?? new List<AttributeLibDm>());
+        aspectObjectAttributeDms.AddRange(AspectObjectAttributes ?? new List<AspectObjectAttributeLibDm>());
 
-        if (!attributeDms.Select(x => x.Id).Order().SequenceEqual(attributeAmIds.Order()))
+        if (!aspectObjectAttributeDms.Select(x => x.AttributeId).Order().SequenceEqual(attributeAmIds.Order()))
         {
             major = true;
         }
@@ -176,9 +175,9 @@ public class AspectObjectLibDm : IVersionable<AspectObjectLibAm>, IVersionObject
             return false;
 
         //Aspect Object Attributes
-        Attributes ??= new List<AttributeLibDm>();
-        other.Attributes ??= new List<AttributeLibDm>();
-        if (!Attributes.Select(x => x.Id).Order().SequenceEqual(other.Attributes.Select(x => x.Id).Order()))
+        AspectObjectAttributes ??= new List<AspectObjectAttributeLibDm>();
+        other.AspectObjectAttributes ??= new List<AspectObjectAttributeLibDm>();
+        if (!AspectObjectAttributes.Select(x => x.AttributeId).Order().SequenceEqual(other.AspectObjectAttributes.Select(x => x.AttributeId).Order()))
         {
             return false;
         }

--- a/src/server/TypeLibrary.Data/Models/TerminalLibDm.cs
+++ b/src/server/TypeLibrary.Data/Models/TerminalLibDm.cs
@@ -19,7 +19,6 @@ public class TerminalLibDm : IStatefulObject, ILogable
     public string Color { get; set; }
     public string Description { get; set; }
     public ICollection<AspectObjectTerminalLibDm> TerminalAspectObjects { get; set; }
-    public ICollection<AttributeLibDm> Attributes { get; set; }
     public ICollection<TerminalAttributeLibDm> TerminalAttributes { get; set; }
 
     #region ILogable

--- a/src/server/TypeLibrary.Data/Repositories/Ef/EfAspectObjectRepository.cs
+++ b/src/server/TypeLibrary.Data/Repositories/Ef/EfAspectObjectRepository.cs
@@ -59,7 +59,8 @@ public class EfAspectObjectRepository : GenericRepository<TypeLibraryDbContext, 
         return GetAll()
             .Include(x => x.AspectObjectTerminals)
             .ThenInclude(x => x.Terminal)
-            .Include(x => x.Attributes)
+            .Include(x => x.AspectObjectAttributes)
+            .ThenInclude(x => x.Attribute)
             .Include(x => x.Rds)
             .AsSplitQuery();
     }
@@ -70,7 +71,8 @@ public class EfAspectObjectRepository : GenericRepository<TypeLibraryDbContext, 
         return FindBy(x => x.Id == id)
             .Include(x => x.AspectObjectTerminals)
             .ThenInclude(x => x.Terminal)
-            .Include(x => x.Attributes)
+            .Include(x => x.AspectObjectAttributes)
+            .ThenInclude(x => x.Attribute)
             .Include(x => x.Rds)
             .AsSplitQuery()
             .FirstOrDefault();
@@ -82,7 +84,8 @@ public class EfAspectObjectRepository : GenericRepository<TypeLibraryDbContext, 
         return FindBy(x => x.FirstVersionId == aspectObject.FirstVersionId)
             .Include(x => x.AspectObjectTerminals)
             .ThenInclude(x => x.Terminal)
-            .Include(x => x.Attributes)
+            .Include(x => x.AspectObjectAttributes)
+            .ThenInclude(x => x.Attribute)
             .Include(x => x.Rds)
             .AsSplitQuery();
     }

--- a/src/server/TypeLibrary.Data/Repositories/Ef/EfTerminalRepository.cs
+++ b/src/server/TypeLibrary.Data/Repositories/Ef/EfTerminalRepository.cs
@@ -52,14 +52,14 @@ public class EfTerminalRepository : GenericRepository<TypeLibraryDbContext, Term
     public IEnumerable<TerminalLibDm> Get()
     {
         return GetAll()
-            .Include(x => x.Attributes);
+            .Include(x => x.TerminalAttributes);
     }
 
     /// <inheritdoc />
     public TerminalLibDm Get(string id)
     {
         var terminal = FindBy(x => x.Id == id)
-            .Include(x => x.Attributes)
+            .Include(x => x.TerminalAttributes)
             .FirstOrDefault();
         return terminal;
     }

--- a/src/server/TypeLibrary.Data/Repositories/Ef/EfTerminalRepository.cs
+++ b/src/server/TypeLibrary.Data/Repositories/Ef/EfTerminalRepository.cs
@@ -52,7 +52,8 @@ public class EfTerminalRepository : GenericRepository<TypeLibraryDbContext, Term
     public IEnumerable<TerminalLibDm> Get()
     {
         return GetAll()
-            .Include(x => x.TerminalAttributes);
+            .Include(x => x.TerminalAttributes)
+            .ThenInclude(x => x.Attribute);
     }
 
     /// <inheritdoc />
@@ -60,6 +61,7 @@ public class EfTerminalRepository : GenericRepository<TypeLibraryDbContext, Term
     {
         var terminal = FindBy(x => x.Id == id)
             .Include(x => x.TerminalAttributes)
+            .ThenInclude(x => x.Attribute)
             .FirstOrDefault();
         return terminal;
     }

--- a/src/server/TypeLibrary.Services/Services/AspectObjectService.cs
+++ b/src/server/TypeLibrary.Services/Services/AspectObjectService.cs
@@ -290,7 +290,7 @@ public class AspectObjectService : IAspectObjectService
 
         // Delete removed attributes, and add new attributes
         var currentAspectObjectAttributes = aspectObjectToUpdate.AspectObjectAttributes.ToHashSet();
-        var newAttributes = new HashSet<AttributeLibDm>();
+        var newAspectObjectAttributes = new HashSet<AspectObjectAttributeLibDm>();
 
         if (aspectObjectAm.Attributes != null)
         {
@@ -304,12 +304,12 @@ public class AspectObjectService : IAspectObjectService
                 }
                 else
                 {
-                    newAttributes.Add(attribute);
+                    newAspectObjectAttributes.Add(new AspectObjectAttributeLibDm { AspectObjectId = aspectObjectToUpdate.Id, AttributeId = attribute.Id });
                 }
             }
         }
 
-        foreach (var aspectObjectAttribute in currentAspectObjectAttributes.ExceptBy(newAttributes.Select(x => x.Id), y => y.AttributeId))
+        foreach (var aspectObjectAttribute in currentAspectObjectAttributes.ExceptBy(newAspectObjectAttributes.Select(x => x.AttributeId), y => y.AttributeId))
         {
             var aspectObjectAttributeToDelete = _aspectObjectAttributeRepository.FindBy(x => x.AspectObjectId == aspectObjectToUpdate.Id && x.AttributeId == aspectObjectAttribute.AttributeId).FirstOrDefault();
 
@@ -319,12 +319,12 @@ public class AspectObjectService : IAspectObjectService
             await _aspectObjectAttributeRepository.Delete(aspectObjectAttributeToDelete.Id);
         }
 
-        foreach (var attribute in newAttributes.ExceptBy(currentAspectObjectAttributes.Select(x => x.AttributeId), y => y.Id))
+        foreach (var aspectObjectAttribute in newAspectObjectAttributes.ExceptBy(currentAspectObjectAttributes.Select(x => x.AttributeId), y => y.AttributeId))
         {
             aspectObjectToUpdate.AspectObjectAttributes.Add(new AspectObjectAttributeLibDm
             {
                 AspectObjectId = aspectObjectToUpdate.Id,
-                AttributeId = attribute.Id
+                AttributeId = aspectObjectAttribute.AttributeId
             });
         }
 

--- a/src/server/TypeLibrary.Services/Services/AspectObjectService.cs
+++ b/src/server/TypeLibrary.Services/Services/AspectObjectService.cs
@@ -151,7 +151,7 @@ public class AspectObjectService : IAspectObjectService
         if (!validation.IsValid)
             throw new MimirorgBadRequestException("Aspect object is not valid.", validation);
 
-        var aspectObjectToUpdate = _aspectObjectRepository.FindBy(x => x.Id == id, false).Include(x => x.AspectObjectTerminals).Include(x => x.Attributes).AsSplitQuery().FirstOrDefault();
+        var aspectObjectToUpdate = _aspectObjectRepository.FindBy(x => x.Id == id, false).Include(x => x.AspectObjectTerminals).Include(x => x.AspectObjectAttributes).AsSplitQuery().FirstOrDefault();
 
         if (aspectObjectToUpdate == null)
             throw new MimirorgNotFoundException("Aspect object not found. Update is not possible.");
@@ -262,7 +262,6 @@ public class AspectObjectService : IAspectObjectService
 
         aspectObjectToUpdate.SelectedAttributePredefined = tempDm.SelectedAttributePredefined;
         aspectObjectToUpdate.AspectObjectTerminals ??= new List<AspectObjectTerminalLibDm>();
-        aspectObjectToUpdate.Attributes ??= new List<AttributeLibDm>();
         aspectObjectToUpdate.AspectObjectAttributes ??= new List<AspectObjectAttributeLibDm>();
 
         tempDm.AspectObjectTerminals ??= new List<AspectObjectTerminalLibDm>();
@@ -290,7 +289,7 @@ public class AspectObjectService : IAspectObjectService
         }
 
         // Delete removed attributes, and add new attributes
-        var currentAttributes = aspectObjectToUpdate.Attributes.ToHashSet();
+        var currentAspectObjectAttributes = aspectObjectToUpdate.AspectObjectAttributes.ToHashSet();
         var newAttributes = new HashSet<AttributeLibDm>();
 
         if (aspectObjectAm.Attributes != null)
@@ -310,17 +309,17 @@ public class AspectObjectService : IAspectObjectService
             }
         }
 
-        foreach (var attribute in currentAttributes.ExceptBy(newAttributes.Select(x => x.Id), y => y.Id))
+        foreach (var aspectObjectAttribute in currentAspectObjectAttributes.ExceptBy(newAttributes.Select(x => x.Id), y => y.AttributeId))
         {
-            var aspectObjectAttribute = _aspectObjectAttributeRepository.FindBy(x => x.AspectObjectId == aspectObjectToUpdate.Id && x.AttributeId == attribute.Id).FirstOrDefault();
+            var aspectObjectAttributeToDelete = _aspectObjectAttributeRepository.FindBy(x => x.AspectObjectId == aspectObjectToUpdate.Id && x.AttributeId == aspectObjectAttribute.AttributeId).FirstOrDefault();
 
-            if (aspectObjectAttribute == null)
+            if (aspectObjectAttributeToDelete == null)
                 continue;
 
-            await _aspectObjectAttributeRepository.Delete(aspectObjectAttribute.Id);
+            await _aspectObjectAttributeRepository.Delete(aspectObjectAttributeToDelete.Id);
         }
 
-        foreach (var attribute in newAttributes.ExceptBy(currentAttributes.Select(x => x.Id), y => y.Id))
+        foreach (var attribute in newAttributes.ExceptBy(currentAspectObjectAttributes.Select(x => x.AttributeId), y => y.Id))
         {
             aspectObjectToUpdate.AspectObjectAttributes.Add(new AspectObjectAttributeLibDm
             {
@@ -372,7 +371,7 @@ public class AspectObjectService : IAspectObjectService
                 await _rdsService.ChangeState(dm.RdsId, State.Review, true);
             }
 
-            foreach (var attribute in dm.Attributes)
+            foreach (var attribute in dm.AspectObjectAttributes.Select(x => x.Attribute))
             {
                 if (attribute.State == State.Approved)
                     continue;
@@ -395,7 +394,7 @@ public class AspectObjectService : IAspectObjectService
             if (dm.Rds.State != State.Approved)
                 throw new MimirorgInvalidOperationException("Cannot approve aspect object that uses unapproved RDS.");
 
-            if (dm.Attributes.Any(attribute => attribute.State != State.Approved))
+            if (dm.AspectObjectAttributes.Select(x => x.Attribute).Any(attribute => attribute.State != State.Approved))
                 throw new MimirorgInvalidOperationException("Cannot approve aspect object that uses unapproved attributes.");
 
             if (dm.AspectObjectTerminals.Select(x => x.Terminal).Any(terminal => terminal.State != State.Approved))


### PR DESCRIPTION
Fixed an issue where attributes of terminals and aspect objects weren't returned from the API endpoint.

The reason for the introduction of the bug was a change in the database configuration for the many-to-many-relations between attributes and terminals/aspect object that was needed to get cascade delete to work.